### PR TITLE
fix: Add `D` as one of the actions on Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ The jsonb WAL record is in the following format for inserts and updates.
     ]
 }
 ```
-where `action` may be `I` or `U` for insert, updated, and delete respectively.
+where `action` may be `I`, `U` or `D` for insert, updated, and delete respectively.
 
 When the WAL record represents a truncate (`action` = `T`) no column information is included and it should be sent to all subscribed users, regardless of their user defined filters e.g.
 ```json

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ The jsonb WAL record is in the following format for inserts and updates.
     ]
 }
 ```
-where `action` may be `I`, `U` or `D` for insert, updated, and delete respectively.
+where `action` may be `I` or `U` for insert and updated, respectively.
 
 When the WAL record represents a truncate (`action` = `T`) no column information is included and it should be sent to all subscribed users, regardless of their user defined filters e.g.
 ```json


### PR DESCRIPTION
## What kind of change does this PR introduce?

Super small fix to add `D` as one of the action types in the description of Readme.md.

## What is the current behavior?

`D` is omitted as a value of action types. 

## What is the new behavior?

`D` is listed as one of the action types. 

## Additional context

I cannot express the excitement I'm having for this repo! Thank you so much for such an amazing tool!
