### PR TITLE
Single Record Throughput Performance Tweaks

### DIFF
--- a/.github/ISSUE_TEMPLATE/rfc.md
+++ b/.github/ISSUE_TEMPLATE/rfc.md
@@ -36,7 +36,7 @@ What are the negative trade-offs?
 # Alternatives
 [alternatives]: #alternatives
 
-What other solutions have been considered? 
+What other solutions have been considered?
 
 # Unresolved Questions
 [unresolved]: #unresolved-questions

--- a/sql/walrus--0.1.sql
+++ b/sql/walrus--0.1.sql
@@ -62,7 +62,7 @@ declare
         )
         from information_schema.columns c
         where
-            (c.table_schema || '.' || c.table_name)::regclass = new.entity
+            (quote_ident(c.table_schema) || '.' || quote_ident(c.table_name))::regclass = new.entity
             and pg_catalog.has_column_privilege(
                 'authenticated',
                 new.entity,

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -17,7 +17,7 @@ def dockerize_database():
 
     # Skip if we're using github actions CI
     if not "GITHUB_SHA" in os.environ:
-        subprocess.call(["docker", "compose", "up", "-d"])
+        subprocess.call(["docker-compose", "up", "-d"])
         # Wait for postgres to become healthy
         for _ in range(10):
             print(1)
@@ -32,7 +32,7 @@ def dockerize_database():
         else:
             raise Exception("Container never became healthy")
         yield
-        subprocess.call(["docker", "compose", "down", "-v"])
+        subprocess.call(["docker-compose", "down", "-v"])
         return
     yield
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -9,7 +9,7 @@ import pytest
 from sqlalchemy import create_engine, text
 from sqlalchemy.orm import Session
 
-CONTAINER_NAME = "wal_rls_db_1"
+CONTAINER_NAME = "walrus_db_1"
 
 
 @pytest.fixture(scope="session")
@@ -25,6 +25,7 @@ def dockerize_database():
             container_info = json.loads(out)
             container_health_status = container_info[0]["State"]["Health"]["Status"]
             if container_health_status == "healthy":
+                time.sleep(1)
                 break
             else:
                 time.sleep(1)
@@ -48,7 +49,31 @@ def sess(engine):
 
     conn = engine.connect()
     conn.execute(
-        text("select * from pg_create_logical_replication_slot('rls_poc', 'wal2json')")
+        text(
+            """
+select * from pg_create_logical_replication_slot('rls_poc', 'wal2json');
+
+create or replace function benchmark(sql text, n int)
+  returns interval
+  language plpgsql AS
+$$
+/*
+	Benchmark an idempotent SQL statement
+*/
+declare
+   i int;
+   start_time timestamp;
+begin
+    start_time := clock_timestamp();
+	for i in 1 .. n loop
+		-- UNSAFE
+		execute sql;
+	end loop;
+	return (clock_timestamp() - start_time) / n;
+end
+$$;
+            """
+        )
     )
     conn.execute(text("commit"))
     # Bind a session to the top level transaction


### PR DESCRIPTION
## What kind of change does this PR introduce?
- Removes dead code
- Inline single use functions to reduce function call overhead
- Combines multiple data structures into `cdc.wal_column`
- Replaces `information_schema` based permissions check with `pg_catalog.has_column_privilege` (big impact)
- Adds a helper utility for benchmarking (during tests only)

## Additional context
Overall impact on processing time:
- decreases processing time from ~11ms to ~5ms for a single record with a single subscriber