### PR TITLE
format `commit_timestamp` as iso8601

### DIFF
--- a/sql/walrus--0.1.sql
+++ b/sql/walrus--0.1.sql
@@ -312,7 +312,7 @@ begin
         'schema', wal ->> 'schema',
         'table', wal ->> 'table',
         'type', action,
-        'commit_timestamp', wal ->> 'timestamp',
+        'commit_timestamp', (wal ->> 'timestamp')::text::timestamp with time zone,
         'columns', (
             select
                 jsonb_agg(


### PR DESCRIPTION
## What kind of change does this PR introduce?
update the `commit_timestamp` to iso8601 tz format to match existing realtime key

resolves #14 