### PR TITLE
fix: delete cascade subscriptions when user is deleted

### DIFF
--- a/sql/walrus--0.1.sql
+++ b/sql/walrus--0.1.sql
@@ -26,7 +26,7 @@ create type cdc.user_defined_filter as (
 create table cdc.subscription (
     -- Tracks which users are subscribed to each table
     id bigint not null generated always as identity,
-    user_id uuid not null references auth.users(id),
+    user_id uuid not null references auth.users(id) on delete cascade,
     -- Populated automatically by trigger. Required to enable auth.email()
     email varchar(255),
     entity regclass not null,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

user can't be deleted from `auth.users` table b/c of `cdc.subscription` user reference.

## What is the new behavior?

when user is deleted from `auth.users` then all related user subscriptions are deleted from `cdc.subscription` b/c of `on delete cascade`.

## Additional context

Delete user: https://supabase.io/docs/reference/javascript/delete-user