### PR TITLE
wal2json qualified table name quoting

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ with pub as (
                     case when bool_or(pubtruncate) then 'truncate' else null end
                 ]) act(name_)
         ) w2j_actions,
-        string_agg(prrelid::regclass::text, ',') w2j_add_tables
+        string_agg(cdc.quote_wal2json(prrelid::regclass), ',') w2j_add_tables
     from
         pg_publication pp
         left join pg_publication_rel ppr

--- a/sql/walrus--0.1.sql
+++ b/sql/walrus--0.1.sql
@@ -105,6 +105,43 @@ grant all on cdc.subscription to postgres;
 grant select on cdc.subscription to authenticated;
 
 
+create or replace function cdc.quote_wal2json(entity regclass)
+    returns text
+    language sql
+    immutable
+    strict
+as $$
+    select
+        (
+            select string_agg('\' || ch,'')
+            from unnest(string_to_array(nsp.nspname::text, null)) with ordinality x(ch, idx)
+            where
+                not (x.idx = 1 and x.ch = '"')
+                and not (
+                    x.idx = array_length(string_to_array(nsp.nspname::text, null), 1)
+                    and x.ch = '"'
+                )
+        )
+        || '.'
+        || (
+            select string_agg('\' || ch,'')
+            from unnest(string_to_array(pc.relname::text, null)) with ordinality x(ch, idx)
+            where
+                not (x.idx = 1 and x.ch = '"')
+                and not (
+                    x.idx = array_length(string_to_array(nsp.nspname::text, null), 1)
+                    and x.ch = '"'
+                )
+        )
+    from
+        pg_class pc
+        join pg_namespace nsp
+            on pc.relnamespace = nsp.oid
+    where
+        pc.oid = entity
+$$;
+
+
 create or replace function cdc.check_equality_op(
     op cdc.equality_op,
     type_ regtype,

--- a/test/test_slot.py
+++ b/test/test_slot.py
@@ -66,7 +66,7 @@ with pub as (
                     case when bool_or(pubtruncate) then 'truncate' else null end
                 ]) act(name_)
         ) w2j_actions,
-        string_agg(prrelid::regclass::text, ',') w2j_add_tables
+        string_agg(cdc.quote_wal2json(prrelid::regclass), ',') w2j_add_tables
     from
         pg_publication pp
         left join pg_publication_rel ppr


### PR DESCRIPTION
## What kind of change does this PR introduce?

Updates test suite and README example showing how to use a publication to correctly quote tables in the nonstandard way required by `wal2json`'s `filter-tables` and `add-tables` options. 

The wal2json table name parser is implemented here:
https://github.com/eulerto/wal2json/blob/master/wal2json.c#L2816

and is described in the docs as:
> The tables should be schema-qualified. *.foo means table foo in all schemas and bar.* means all tables in schema bar. Special characters (space, single quote, comma, period, asterisk) must be escaped with backslash. Schema and table are case-sensitive. Table "public"."Foo bar" should be specified as public.Foo\ bar.

The new function
```sql
cdc.quote_wal2json(entity regclass)
```
translates from postgres' `regclass` form to indiscriminately quoting every character (which wal2json accepts, despite looking ridiculous) to eliminate having to test every edge case.

e.g.
```
select cdc.quote_wal2json('public."tab""le*_A"'::regclass)

'\p\u\b\l\i\c.\t\a\b\"\l\e\*\_\A'
```

## What is the current behavior?

tables are not not quoted

## What is the new behavior?

tables are quoted