### PR TITLE
Return unauthorized error when `authenticated` can not select from table

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,20 @@ Important Notes:
 - The key/value pairs displayed in the `old_record` field include the table's identity columns for the record being updated/deleted. To display all values in `old_record` set the replica identity for the table to full
 - When a delete occurs, the contents of `old_record` will be broadcast to all subscribers to that table so ensure that each table's replica identity only contains information that is safe to expose publicly
 
+## Error States
+
+### Unauthorized 401
+If a WAL record is passed through `cdc.apply_rls` and the `authenticated` role does not have permission to `select` and of the columns in that table, an `Unauthorized` error is returned with no WAL data.
+
+```sql
+(
+    null, -- wal
+    null, -- is_rls_enabled
+    [],   -- users,
+    array['Error 401: Unauthorized'] -- errors
+)::cdc.wal_rls;
+```
+
 
 ## How it Works
 

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ Important Notes:
 ## Error States
 
 ### Unauthorized 401
-If a WAL record is passed through `cdc.apply_rls` and the `authenticated` role does not have permission to `select` and of the columns in that table, an `Unauthorized` error is returned with no WAL data.
+If a WAL record is passed through `cdc.apply_rls` and the `authenticated` role does not have permission to `select` any of the columns in that table, an `Unauthorized` error is returned with no WAL data.
 
 ```sql
 (

--- a/README.md
+++ b/README.md
@@ -183,18 +183,31 @@ Important Notes:
 
 ## Error States
 
-### Unauthorized 401
+### Error 401: Unauthorized
 If a WAL record is passed through `cdc.apply_rls` and the `authenticated` role does not have permission to `select` any of the columns in that table, an `Unauthorized` error is returned with no WAL data.
 
+Ex:
 ```sql
 (
-    null, -- wal
-    null, -- is_rls_enabled
-    [],   -- users,
+    null,                            -- wal
+    null,                            -- is_rls_enabled
+    [],                              -- users,
     array['Error 401: Unauthorized'] -- errors
 )::cdc.wal_rls;
 ```
 
+### Error 413: Payload Too Large
+When the size of the wal2json record exceeds `max_record_bytes` the `record` and `old_record` keys are set as empty objects `{}` and the `errors` output array will contain the string `"Error 413: Payload Too Large"`
+
+Ex:
+```sql
+(
+    {..., "record": {}, "old_record": {}}, -- wal
+    true,                                  -- is_rls_enabled
+    [...],                                 -- users,
+    array['Error 413: Payload Too Large']  -- errors
+)::cdc.wal_rls;
+```
 
 ## How it Works
 

--- a/sql/walrus--0.1.sql
+++ b/sql/walrus--0.1.sql
@@ -343,12 +343,23 @@ declare
 
     -- Error states
     error_record_exceeds_max_size boolean = octet_length(wal::text) > max_record_bytes;
+    error_unauthorized boolean = not pg_catalog.has_any_column_privilege('authenticated', entity_, 'SELECT');
 
     errors text[] = case
         when error_record_exceeds_max_size then array['Error 413: Payload Too Large']
         else '{}'::text[]
     end;
 begin
+
+    -- The 'authenticated' user does not have SELECT permission on any of the columns for the entity_
+    if error_unauthorized is true then
+        return (
+            null,
+            null,
+            visible_to_user_ids,
+            array['Error 401: Unauthorized']
+        )::cdc.wal_rls;
+    end if;
 
     -------------------------------
     -- Build Output JSONB Object --

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -66,9 +66,22 @@ create table public.note(
 );
 create index ix_note_user_id on public.note (user_id);
 
+create table public.unauthorized(
+    id bigserial primary key
+);
+
+
 drop publication if exists supabase_realtime;
 
-create publication supabase_realtime for table public.note with (publish = 'insert,update,delete,truncate');
+
+create publication
+    supabase_realtime
+for table
+    public.note,
+    public.unauthorized
+with (
+    publish = 'insert,update,delete,truncate'
+);
             """
         )
     )


### PR DESCRIPTION
## What kind of change does this PR introduce?

If a WAL record is passed through `cdc.apply_rls`, the `authenticated` role does not have permission to `select` any of the columns in that table, an `Unauthorized` error is returned with no WAL data.

## What is the current behavior?

The WAL record is returned with a empty `record` and `old_record` keys