### PR TITLE
Update auth/tests for PostgREST 9 compatibility

### DIFF
--- a/sql/setup.sql
+++ b/sql/setup.sql
@@ -99,16 +99,30 @@ VALUES  ('20171026211738'),
         ('20180125194653');
 -- Gets the User ID from the request cookie
 create or replace function auth.uid() returns uuid as $$
-  select nullif(current_setting('request.jwt.claim.sub', true), '')::uuid;
+    select
+        coalesce(
+            nullif(current_setting('request.jwt.claim.sub', true), ''),
+            nullif(current_setting('request.jwt.claims', true), '')::jsonb ->> 'sub'
+        )::uuid;
 $$ language sql stable;
 -- Gets the User Role from the request cookie
 create or replace function auth.role() returns text as $$
-  select nullif(current_setting('request.jwt.claim.role', true), '')::text;
+  select
+        coalesce(
+            nullif(current_setting('request.jwt.claim.role', true), ''),
+            nullif(current_setting('request.jwt.claims', true), '')::jsonb ->> 'role'
+        )::text;
 $$ language sql stable;
+
 -- Gets the User Email from the request cookie
 create or replace function auth.email() returns text as $$
-  select nullif(current_setting('request.jwt.claim.email', true), '')::text;
+  select
+        coalesce(
+            nullif(current_setting('request.jwt.claim.email', true), ''),
+            nullif(current_setting('request.jwt.claims', true), '')::jsonb ->> 'email'
+        )::text;
 $$ language sql stable;
+
 GRANT ALL PRIVILEGES ON SCHEMA auth TO postgres;
 GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA auth TO postgres;
 GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA auth TO postgres;

--- a/sql/setup.sql
+++ b/sql/setup.sql
@@ -101,16 +101,16 @@ VALUES  ('20171026211738'),
 create or replace function auth.uid() returns uuid as $$
     select
         coalesce(
-            nullif(current_setting('request.jwt.claim.sub', true), ''),
-            nullif(current_setting('request.jwt.claims', true), '')::jsonb ->> 'sub'
+            current_setting('request.jwt.claim.sub', true),
+            current_setting('request.jwt.claims', true)::jsonb ->> 'sub'
         )::uuid;
 $$ language sql stable;
 -- Gets the User Role from the request cookie
 create or replace function auth.role() returns text as $$
   select
         coalesce(
-            nullif(current_setting('request.jwt.claim.role', true), ''),
-            nullif(current_setting('request.jwt.claims', true), '')::jsonb ->> 'role'
+            current_setting('request.jwt.claim.role', true),
+            current_setting('request.jwt.claims', true)::jsonb ->> 'role'
         )::text;
 $$ language sql stable;
 
@@ -118,8 +118,8 @@ $$ language sql stable;
 create or replace function auth.email() returns text as $$
   select
         coalesce(
-            nullif(current_setting('request.jwt.claim.email', true), ''),
-            nullif(current_setting('request.jwt.claims', true), '')::jsonb ->> 'email'
+            current_setting('request.jwt.claim.email', true),
+            current_setting('request.jwt.claims', true)::jsonb ->> 'email'
         )::text;
 $$ language sql stable;
 


### PR DESCRIPTION
## What kind of change does this PR introduce?
Update auth/tests for PostgREST 9 compatibility & removes support for PostgREST < 9 auth.