### PR TITLE
Friendly error message for tables with no primary key

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,20 @@ Important Notes:
 
 ## Error States
 
+### Error 400: Bad Request, no primary key
+If a WAL record for a table that does not have a primary key is passed through `cdc.apply_rls`, an error is returned
+
+Ex:
+```sql
+(
+    null,                            -- wal
+    null,                            -- is_rls_enabled
+    [],                              -- users,
+    array['Error 400: Bad Request, no primary key'] -- errors
+)::cdc.wal_rls;
+```
+
+
 ### Error 401: Unauthorized
 If a WAL record is passed through `cdc.apply_rls` and the `authenticated` role does not have permission to `select` any of the columns in that table, an `Unauthorized` error is returned with no WAL data.
 


### PR DESCRIPTION
## What kind of change does this PR introduce?
Adds an error response when the WAL record passing through `cdc.apply_rls` is from a table that does not have a primary key

```sql
(
    null,                            -- wal
    null,                            -- is_rls_enabled
    [],                              -- users,
    array['Error 400: Bad Request, no primary key'] -- errors
)::cdc.wal_rls;
```


## What is the current behavior?
Crashes with 
```
ERROR:  query string argument of EXECUTE is null
CONTEXT:  PL/pgSQL function realtime.apply_rls(jsonb,integer) line 146 at EXECUTE
```