### PR TITLE
Align schema and actions with Realtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,40 +23,40 @@ The subscription stream is based on logical replication slots.
 User subscriptions are managed through a table
 
 ```sql
-create table cdc.subscription (
+create table realtime.subscription (
     id bigint not null generated always as identity,
     user_id uuid not null,
     entity regclass not null,
-    filters cdc.user_defined_filter[],
+    filters realtime.user_defined_filter[],
     created_at timestamp not null default timezone('utc', now()),
     constraint pk_subscription primary key (id)
 );
 ```
-where `cdc.user_defined_filter` is
+where `realtime.user_defined_filter` is
 ```sql
-create type cdc.user_defined_filter as (
+create type realtime.user_defined_filter as (
     column_name text,
-    op cdc.equality_op,
+    op realtime.equality_op,
     value text
 );
 ```
-and `cdc.equality_op`s are a subset of [postgrest ops](https://postgrest.org/en/v4.1/api.html#horizontal-filtering-rows). Specifically:
+and `realtime.equality_op`s are a subset of [postgrest ops](https://postgrest.org/en/v4.1/api.html#horizontal-filtering-rows). Specifically:
 ```sql
-create type cdc.equality_op as enum(
+create type realtime.equality_op as enum(
     'eq', 'neq', 'lt', 'lte', 'gt', 'gte'
 );
 ```
 
 For example, to subscribe a user to table named `public.notes` where the `id` is `6`:
 ```sql
-insert into cdc.subscription(user_id, entity, filters)
+insert into realtime.subscription(user_id, entity, filters)
 values ('832bd278-dac7-4bef-96be-e21c8a0023c4', 'public.notes', array[('id', 'eq', '6')]);
 ```
 
 
 ### Reading WAL
 
-This package exposes 1 public SQL function `cdc.apply_rls(jsonb)`. It processes the output of a `wal2json` decoded logical replication slot and returns:
+This package exposes 1 public SQL function `realtime.apply_rls(jsonb)`. It processes the output of a `wal2json` decoded logical replication slot and returns:
 
 - `wal`: (jsonb) The WAL record as JSONB in the form
 - `is_rls_enabled`: (bool) If the entity (table) the WAL record represents has row level security enabled
@@ -184,7 +184,7 @@ Important Notes:
 ## Error States
 
 ### Error 401: Unauthorized
-If a WAL record is passed through `cdc.apply_rls` and the `authenticated` role does not have permission to `select` any of the columns in that table, an `Unauthorized` error is returned with no WAL data.
+If a WAL record is passed through `realtime.apply_rls` and the `authenticated` role does not have permission to `select` any of the columns in that table, an `Unauthorized` error is returned with no WAL data.
 
 Ex:
 ```sql
@@ -193,7 +193,7 @@ Ex:
     null,                            -- is_rls_enabled
     [],                              -- users,
     array['Error 401: Unauthorized'] -- errors
-)::cdc.wal_rls;
+)::realtime.wal_rls;
 ```
 
 ### Error 413: Payload Too Large
@@ -206,12 +206,12 @@ Ex:
     true,                                  -- is_rls_enabled
     [...],                                 -- users,
     array['Error 413: Payload Too Large']  -- errors
-)::cdc.wal_rls;
+)::realtime.wal_rls;
 ```
 
 ## How it Works
 
-Each WAL record is passed into `cdc.apply_rls(jsonb)` which:
+Each WAL record is passed into `realtime.apply_rls(jsonb)` which:
 
 - impersonates each subscribed user by setting `request.jwt.claims` to an object with `sub` (user's id), `email` (user's email), and `role` ('authenticated')
 - queries for the row using its primary key values
@@ -246,7 +246,7 @@ from
         'write-in-chunks', 'true',
         'format-version', '2',
         'actions', 'insert,update,delete,truncate',
-        'filter-tables', 'cdc.*'
+        'filter-tables', 'realtime.*'
     ),
     lateral (
         select
@@ -255,7 +255,7 @@ from
             x.users,
             x.errors
         from
-            cdc.apply_rls(data::jsonb) x(wal, is_rls_enabled, users, errors)
+            realtime.apply_rls(data::jsonb) x(wal, is_rls_enabled, users, errors)
     ) xyz
 ```
 
@@ -273,7 +273,7 @@ with pub as (
             case when bool_or(pubdelete) then 'delete' else null end,
             case when bool_or(pubtruncate) then 'truncate' else null end
         ) as w2j_actions,
-        string_agg(cdc.quote_wal2json(format('%I.%I', schemaname, tablename)::regclass), ',') w2j_add_tables
+        string_agg(realtime.quote_wal2json(format('%I.%I', schemaname, tablename)::regclass), ',') w2j_add_tables
     from
         pg_publication pp
         join pg_publication_tables ppt
@@ -313,7 +313,7 @@ from
             x.users,
             x.errors
         from
-            cdc.apply_rls(
+            realtime.apply_rls(
                 wal := w2j.data::jsonb,
                 max_record_bytes := 1048576
             ) x(wal, is_rls_enabled, users, errors)
@@ -330,7 +330,7 @@ where
 
 Ex:
 ```sql
-cdc.apply_rls(wal := w2j.data::jsonb, max_record_bytes := 1024*1024) x(wal, is_rls_enabled, users, errors)
+realtime.apply_rls(wal := w2j.data::jsonb, max_record_bytes := 1024*1024) x(wal, is_rls_enabled, users, errors)
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -151,30 +151,6 @@ deletes:
 }
 ```
 
-and truncates
-```json
-{
-    "type": "TRUNCATE",
-    "schema": "public",
-    "table": "todos",
-    "columns": [
-        {
-            "name": "id",
-            "type": "int8",
-        },
-        {
-            "name": "details",
-            "type": "text",
-        },
-        {
-            "name": "user_id",
-            "type": "int8",
-        }
-    ],
-    "commit_timestamp": "2021-09-29T17:35:38Z"
-}
-```
-
 Important Notes:
 
 - Row level security is not applied to delete statements
@@ -245,7 +221,7 @@ from
         'include-timestamp', 'true',
         'write-in-chunks', 'true',
         'format-version', '2',
-        'actions', 'insert,update,delete,truncate',
+        'actions', 'insert,update,delete',
         'filter-tables', 'realtime.*'
     ),
     lateral (
@@ -270,8 +246,7 @@ with pub as (
             ',',
             case when bool_or(pubinsert) then 'insert' else null end,
             case when bool_or(pubupdate) then 'update' else null end,
-            case when bool_or(pubdelete) then 'delete' else null end,
-            case when bool_or(pubtruncate) then 'truncate' else null end
+            case when bool_or(pubdelete) then 'delete' else null end
         ) as w2j_actions,
         string_agg(realtime.quote_wal2json(format('%I.%I', schemaname, tablename)::regclass), ',') w2j_add_tables
     from

--- a/sql/walrus--0.1.sql
+++ b/sql/walrus--0.1.sql
@@ -13,7 +13,7 @@ create type realtime.equality_op as enum(
 );
 
 
-create type realtime.action as enum ('INSERT', 'UPDATE', 'DELETE', 'TRUNCATE', 'ERROR');
+create type realtime.action as enum ('INSERT', 'UPDATE', 'DELETE', 'ERROR');
 
 
 create function realtime.cast(val text, type_ regtype)
@@ -282,7 +282,6 @@ declare
             when 'I' then 'INSERT'
             when 'U' then 'UPDATE'
             when 'D' then 'DELETE'
-            when 'T' then 'TRUNCATE'
             else 'ERROR'
         end
     );
@@ -407,7 +406,7 @@ begin
         else '{}'::jsonb
     end;
 
-    if action in ('TRUNCATE', 'DELETE') then
+    if action = 'DELETE' then
         visible_to_user_ids = array_agg(s.user_id) from unnest(subscriptions) s;
     else
         -- If RLS is on and someone is subscribed to the table prep

--- a/sql/walrus--0.1.sql
+++ b/sql/walrus--0.1.sql
@@ -3,20 +3,20 @@
         Write Ahead Log Realtime Unified Security
 */
 
-create schema cdc;
-grant usage on schema cdc to postgres;
-grant usage on schema cdc to authenticated;
+create schema realtime;
+grant usage on schema realtime to postgres;
+grant usage on schema realtime to authenticated;
 
 
-create type cdc.equality_op as enum(
+create type realtime.equality_op as enum(
     'eq', 'neq', 'lt', 'lte', 'gt', 'gte'
 );
 
 
-create type cdc.action as enum ('INSERT', 'UPDATE', 'DELETE', 'TRUNCATE', 'ERROR');
+create type realtime.action as enum ('INSERT', 'UPDATE', 'DELETE', 'TRUNCATE', 'ERROR');
 
 
-create function cdc.cast(val text, type_ regtype)
+create function realtime.cast(val text, type_ regtype)
     returns jsonb
     immutable
     language plpgsql
@@ -30,30 +30,30 @@ end
 $$;
 
 
-create type cdc.user_defined_filter as (
+create type realtime.user_defined_filter as (
     column_name text,
-    op cdc.equality_op,
+    op realtime.equality_op,
     value text
 );
 
 
-create table cdc.subscription (
+create table realtime.subscription (
     -- Tracks which users are subscribed to each table
     id bigint not null generated always as identity,
     user_id uuid not null,
     -- Populated automatically by trigger. Required to enable auth.email()
     email varchar(255),
     entity regclass not null,
-    filters cdc.user_defined_filter[] not null default '{}',
+    filters realtime.user_defined_filter[] not null default '{}',
     created_at timestamp not null default timezone('utc', now()),
 
     constraint pk_subscription primary key (id),
     unique (entity, user_id, filters)
 );
-create index ix_cdc_subscription_entity on cdc.subscription using hash (entity);
+create index ix_realtime_subscription_entity on realtime.subscription using hash (entity);
 
 
-create function cdc.subscription_check_filters()
+create function realtime.subscription_check_filters()
     returns trigger
     language plpgsql
 as $$
@@ -72,7 +72,7 @@ declare
         where
             (quote_ident(c.table_schema) || '.' || quote_ident(c.table_name))::regclass = new.entity
             and pg_catalog.has_column_privilege('authenticated', new.entity, c.column_name, 'SELECT');
-    filter cdc.user_defined_filter;
+    filter realtime.user_defined_filter;
     col_type regtype;
 begin
     for filter in select * from unnest(new.filters) loop
@@ -92,7 +92,7 @@ begin
             raise exception 'failed to lookup type for column %', filter.column_name;
         end if;
         -- raises an exception if value is not coercable to type
-        perform cdc.cast(filter.value, col_type);
+        perform realtime.cast(filter.value, col_type);
     end loop;
 
     -- Apply consistent order to filters so the unique constraint on
@@ -107,16 +107,16 @@ end;
 $$;
 
 create trigger tr_check_filters
-    before insert or update on cdc.subscription
+    before insert or update on realtime.subscription
     for each row
-    execute function cdc.subscription_check_filters();
+    execute function realtime.subscription_check_filters();
 
 
-grant all on cdc.subscription to postgres;
-grant select on cdc.subscription to authenticated;
+grant all on realtime.subscription to postgres;
+grant select on realtime.subscription to authenticated;
 
 
-create or replace function cdc.quote_wal2json(entity regclass)
+create or replace function realtime.quote_wal2json(entity regclass)
     returns text
     language sql
     immutable
@@ -153,8 +153,8 @@ as $$
 $$;
 
 
-create or replace function cdc.check_equality_op(
-    op cdc.equality_op,
+create or replace function realtime.check_equality_op(
+    op realtime.equality_op,
     type_ regtype,
     val_1 text,
     val_2 text
@@ -186,7 +186,7 @@ end;
 $$;
 
 
-create type cdc.wal_column as (
+create type realtime.wal_column as (
     name text,
     type text,
     value jsonb,
@@ -194,10 +194,10 @@ create type cdc.wal_column as (
     is_selectable boolean
 );
 
-create or replace function cdc.build_prepared_statement_sql(
+create or replace function realtime.build_prepared_statement_sql(
     prepared_statement_name text,
     entity regclass,
-    columns cdc.wal_column[]
+    columns realtime.wal_column[]
 )
     returns text
     language sql
@@ -207,7 +207,7 @@ Builds a sql string that, if executed, creates a prepared statement to
 tests retrive a row from *entity* by its primary key columns.
 
 Example
-    select cdc.build_prepared_statment_sql('public.notes', '{"id"}'::text[], '{"bigint"}'::text[])
+    select realtime.build_prepared_statment_sql('public.notes', '{"id"}'::text[], '{"bigint"}'::text[])
 */
     select
 'prepare ' || prepared_statement_name || ' as
@@ -229,7 +229,7 @@ Example
 $$;
 
 
-create type cdc.wal_rls as (
+create type realtime.wal_rls as (
     wal jsonb,
     is_rls_enabled boolean,
     users uuid[],
@@ -238,7 +238,7 @@ create type cdc.wal_rls as (
 
 
 
-create or replace function cdc.is_visible_through_filters(columns cdc.wal_column[], filters cdc.user_defined_filter[])
+create or replace function realtime.is_visible_through_filters(columns realtime.wal_column[], filters realtime.user_defined_filter[])
     returns bool
     language sql
     immutable
@@ -250,7 +250,7 @@ Should the record be visible (true) or filtered out (false) after *filters* are 
         -- Default to allowed when no filters present
         coalesce(
             sum(
-                cdc.check_equality_op(
+                realtime.check_equality_op(
                     op:=f.op,
                     type_:=col.type::regtype,
                     -- cast jsonb to text
@@ -267,8 +267,8 @@ Should the record be visible (true) or filtered out (false) after *filters* are 
 $$;
 
 
-create or replace function cdc.apply_rls(wal jsonb, max_record_bytes int = 1024 * 1024)
-    returns cdc.wal_rls
+create or replace function realtime.apply_rls(wal jsonb, max_record_bytes int = 1024 * 1024)
+    returns realtime.wal_rls
     language plpgsql
     volatile
 as $$
@@ -277,7 +277,7 @@ declare
     entity_ regclass = (quote_ident(wal ->> 'schema') || '.' || quote_ident(wal ->> 'table'))::regclass;
 
     -- I, U, D, T: insert, update ...
-    action cdc.action = (
+    action realtime.action = (
         case wal ->> 'action'
             when 'I' then 'INSERT'
             when 'U' then 'UPDATE'
@@ -298,23 +298,23 @@ declare
     visible_to_user_ids uuid[] = '{}';
 
     -- user subscriptions to the wal record's table
-    subscriptions cdc.subscription[] =
+    subscriptions realtime.subscription[] =
             array_agg(sub)
         from
-            cdc.subscription sub
+            realtime.subscription sub
         where
             sub.entity = entity_;
 
     -- structured info for wal's columns
-    columns cdc.wal_column[] =
+    columns realtime.wal_column[] =
         array_agg(
             (
                 x->>'name',
                 x->>'type',
-                cdc.cast((x->'value') #>> '{}', (x->>'type')::regtype),
+                realtime.cast((x->'value') #>> '{}', (x->>'type')::regtype),
                 (pks ->> 'name') is not null,
                 pg_catalog.has_column_privilege('authenticated', entity_, x->>'name', 'SELECT')
-            )::cdc.wal_column
+            )::realtime.wal_column
         )
         from
             jsonb_array_elements(wal -> 'columns') x
@@ -322,15 +322,15 @@ declare
                 on (x ->> 'name') = (pks ->> 'name');
 
     -- previous identity values for update/delete
-    old_columns cdc.wal_column[] =
+    old_columns realtime.wal_column[] =
         array_agg(
             (
                 x->>'name',
                 x->>'type',
-                cdc.cast((x->'value') #>> '{}', (x->>'type')::regtype),
+                realtime.cast((x->'value') #>> '{}', (x->>'type')::regtype),
                 (pks ->> 'name') is not null,
                 pg_catalog.has_column_privilege('authenticated', entity_, x->>'name', 'SELECT')
-            )::cdc.wal_column
+            )::realtime.wal_column
         )
         from
             jsonb_array_elements(wal -> 'identity') x
@@ -356,7 +356,7 @@ begin
             null,
             visible_to_user_ids,
             array['Error 401: Unauthorized']
-        )::cdc.wal_rls;
+        )::realtime.wal_rls;
     end if;
 
     -------------------------------
@@ -416,7 +416,7 @@ begin
             if (select 1 from pg_prepared_statements where name = 'walrus_rls_stmt' limit 1) > 0 then
                 deallocate walrus_rls_stmt;
             end if;
-            execute cdc.build_prepared_statement_sql('walrus_rls_stmt', entity_, columns);
+            execute realtime.build_prepared_statement_sql('walrus_rls_stmt', entity_, columns);
 
         end if;
 
@@ -425,7 +425,7 @@ begin
                 select
                     subs.user_id,
                     subs.email,
-                    cdc.is_visible_through_filters(columns, subs.filters)
+                    realtime.is_visible_through_filters(columns, subs.filters)
                 from
                     unnest(subscriptions) subs
         )
@@ -467,6 +467,6 @@ begin
         is_rls_enabled,
         visible_to_user_ids,
         errors
-    )::cdc.wal_rls;
+    )::realtime.wal_rls;
 end;
 $$;

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -80,7 +80,7 @@ for table
     public.note,
     public.unauthorized
 with (
-    publish = 'insert,update,delete,truncate'
+    publish = 'insert,update,delete'
 );
             """
         )

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -121,7 +121,7 @@ select * from pg_create_logical_replication_slot('realtime', 'wal2json', false);
     alter default privileges in schema public grant all on tables to authenticated;
     alter default privileges in schema public grant all on functions to authenticated;
     alter default privileges in schema public grant all on sequences to authenticated;
-    truncate table cdc.subscription cascade;
+    truncate table realtime.subscription cascade;
     """
     )
     conn.execute(text("commit"))

--- a/test/test_slot.py
+++ b/test/test_slot.py
@@ -49,11 +49,6 @@ class DeleteWAL(BaseWAL):
     old_record: ColValDict
 
 
-class TruncateWAL(BaseWAL):
-    type: Literal["TRUNCATE"]
-    columns: Columns
-
-
 class InsertWAL(BaseWAL):
     type: Literal["INSERT"]
     columns: Columns

--- a/test/test_slot.py
+++ b/test/test_slot.py
@@ -75,8 +75,7 @@ with pub as (
             ',',
             case when bool_or(pubinsert) then 'insert' else null end,
             case when bool_or(pubupdate) then 'update' else null end,
-            case when bool_or(pubdelete) then 'delete' else null end,
-            case when bool_or(pubtruncate) then 'truncate' else null end
+            case when bool_or(pubdelete) then 'delete' else null end
         ) as w2j_actions,
         string_agg(realtime.quote_wal2json(format('%I.%I', schemaname, tablename)::regclass), ',') w2j_add_tables
     from
@@ -333,21 +332,6 @@ def test_wal_update_changed_identity(sess):
     assert wal["record"]["id"] == 99
     assert wal["record"]["body"] == "some body"
     assert wal["old_record"]["id"] == 1
-
-
-def test_wal_truncate(sess):
-    setup_note(sess)
-    setup_note_rls(sess)
-    insert_subscriptions(sess, n=2)
-    insert_notes(sess, n=1)
-    clear_wal(sess)
-    sess.execute("truncate table public.note;")
-    sess.commit()
-    _, wal, is_rls_enabled, users, errors = sess.execute(QUERY).one()
-    TruncateWAL.parse_obj(wal)
-    assert errors == []
-    assert is_rls_enabled
-    assert len(users) == 2
 
 
 def test_wal_delete(sess):

--- a/test/test_user_defined_filters.py
+++ b/test/test_user_defined_filters.py
@@ -46,7 +46,7 @@ def test_user_defined_eq_filter(op, type_, val_1, val_2, result, sess):
     (x,) = sess.execute(
         select(
             [
-                func.cdc.check_equality_op(
+                func.realtime.check_equality_op(
                     op,
                     type_,
                     val_1,


### PR DESCRIPTION
## What kind of change does this PR introduce?
To more closely align walrus with the SQL used in `Realtime`:

- renames the `cdc` schema to `realtime`
- removes the `truncate` action

