### PR TITLE
Support Generic PostgREST 9  Claims

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ site/
 regression.*
 __pycache__/
 *.egg-info/
+*.swp

--- a/README.md
+++ b/README.md
@@ -266,16 +266,38 @@ with pub as (
             case when bool_or(pubupdate) then 'update' else null end,
             case when bool_or(pubdelete) then 'delete' else null end
         ) as w2j_actions,
-        string_agg(realtime.quote_wal2json(format('%I.%I', schemaname, tablename)::regclass), ',') w2j_add_tables
+        coalesce(
+            string_agg(
+                realtime.quote_wal2json(format('%I.%I', schemaname, tablename)::regclass),
+                ','
+            ) filter (where ppt.tablename is not null),
+            ''
+        ) w2j_add_tables
     from
         pg_publication pp
-        join pg_publication_tables ppt
+        left join pg_publication_tables ppt
             on pp.pubname = ppt.pubname
     where
         pp.pubname = 'supabase_realtime'
     group by
         pp.pubname
     limit 1
+),
+w2j as (
+    select
+        x.*, pub.w2j_add_tables
+    from
+         pub,
+         pg_logical_slot_get_changes(
+            'realtime', null, null,
+            'include-pk', '1',
+            'include-transaction', 'false',
+            'include-timestamp', 'true',
+            'write-in-chunks', 'true',
+            'format-version', '2',
+            'actions', pub.w2j_actions,
+            'add-tables', pub.w2j_add_tables
+        ) x
 )
 select
     xyz.wal,
@@ -283,36 +305,13 @@ select
     xyz.subscription_ids,
     xyz.errors
 from
-    pub,
-    lateral (
-          select
-            *
-          from
-             pg_logical_slot_get_changes(
-                'realtime', null, null,
-                'include-pk', '1',
-                'include-transaction', 'false',
-                'include-timestamp', 'true',
-                'write-in-chunks', 'true',
-                'format-version', '2',
-                'actions', coalesce(pub.w2j_actions, ''),
-                'add-tables', pub.w2j_add_tables
-            )
-    ) w2j,
-    lateral (
-        select
-            x.wal,
-            x.is_rls_enabled,
-            x.subscription_ids,
-            x.errors
-        from
-            realtime.apply_rls(
-                wal := w2j.data::jsonb,
-                max_record_bytes := 1048576
-            ) x(wal, is_rls_enabled, subscription_ids, errors)
-    ) xyz
+    w2j,
+    realtime.apply_rls(
+        wal := w2j.data::jsonb,
+        max_record_bytes := 1048576
+    ) xyz(wal, is_rls_enabled, subscription_ids, errors)
 where
-    coalesce(pub.w2j_add_tables, '') <> ''
+    w2j.w2j_add_tables <> ''
     and xyz.subscription_ids[1] is not null
 ```
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ This package exposes 1 public SQL function `realtime.apply_rls(jsonb)`. It proce
 
 - `wal`: (jsonb) The WAL record as JSONB in the form
 - `is_rls_enabled`: (bool) If the entity (table) the WAL record represents has row level security enabled
-- `users`: (uuid[]) An array users who should be notified about the WAL record
+- `subscription_ids`: (uuid[]) An array subscription ids that should be notified about the WAL record
 - `errors`: (text[]) An array of errors
 
 The jsonb WAL record is in the following format for inserts.
@@ -166,7 +166,7 @@ Ex:
 ```sql
 (
     null,                            -- wal
-    null,                            -- is_rls_enabled
+    true,                            -- is_rls_enabled
     [...],                              -- users,
     array['Error 400: Bad Request, no primary key'] -- errors
 )::realtime.wal_rls;
@@ -179,7 +179,7 @@ Ex:
 ```sql
 (
     null,                            -- wal
-    null,                            -- is_rls_enabled
+    true,                            -- is_rls_enabled
     [...],                              -- users,
     array['Error 401: Unauthorized'] -- errors
 )::realtime.wal_rls;

--- a/README.md
+++ b/README.md
@@ -246,6 +246,8 @@ from
         from
             realtime.apply_rls(data::jsonb) x(wal, is_rls_enabled, subcription_ids, errors)
     ) xyz
+where
+    array_length(xyz.subscription_ids, 1) > 0
 ```
 
 Or, if the stream should be filtered according to a publication:
@@ -308,6 +310,7 @@ from
     ) xyz
 where
     coalesce(pub.w2j_add_tables, '') <> ''
+    and array_length(xyz.subscription_ids, 1) > 0
 ```
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -23,40 +23,40 @@ The subscription stream is based on logical replication slots.
 User subscriptions are managed through a table
 
 ```sql
-create table cdc.subscription (
+create table realtime.subscription (
     id bigint not null generated always as identity,
     user_id uuid not null,
     entity regclass not null,
-    filters cdc.user_defined_filter[],
+    filters realtime.user_defined_filter[],
     created_at timestamp not null default timezone('utc', now()),
     constraint pk_subscription primary key (id)
 );
 ```
-where `cdc.user_defined_filter` is
+where `realtime.user_defined_filter` is
 ```sql
-create type cdc.user_defined_filter as (
+create type realtime.user_defined_filter as (
     column_name text,
-    op cdc.equality_op,
+    op realtime.equality_op,
     value text
 );
 ```
-and `cdc.equality_op`s are a subset of [postgrest ops](https://postgrest.org/en/v4.1/api.html#horizontal-filtering-rows). Specifically:
+and `realtime.equality_op`s are a subset of [postgrest ops](https://postgrest.org/en/v4.1/api.html#horizontal-filtering-rows). Specifically:
 ```sql
-create type cdc.equality_op as enum(
+create type realtime.equality_op as enum(
     'eq', 'neq', 'lt', 'lte', 'gt', 'gte'
 );
 ```
 
 For example, to subscribe a user to table named `public.notes` where the `id` is `6`:
 ```sql
-insert into cdc.subscription(user_id, entity, filters)
+insert into realtime.subscription(user_id, entity, filters)
 values ('832bd278-dac7-4bef-96be-e21c8a0023c4', 'public.notes', array[('id', 'eq', '6')]);
 ```
 
 
 ### Reading WAL
 
-This package exposes 1 public SQL function `cdc.apply_rls(jsonb)`. It processes the output of a `wal2json` decoded logical replication slot and returns:
+This package exposes 1 public SQL function `realtime.apply_rls(jsonb)`. It processes the output of a `wal2json` decoded logical replication slot and returns:
 
 - `wal`: (jsonb) The WAL record as JSONB in the form
 - `is_rls_enabled`: (bool) If the entity (table) the WAL record represents has row level security enabled
@@ -184,7 +184,7 @@ Important Notes:
 ## Error States
 
 ### Error 401: Unauthorized
-If a WAL record is passed through `cdc.apply_rls` and the `authenticated` role does not have permission to `select` any of the columns in that table, an `Unauthorized` error is returned with no WAL data.
+If a WAL record is passed through `realtime.apply_rls` and the `authenticated` role does not have permission to `select` any of the columns in that table, an `Unauthorized` error is returned with no WAL data.
 
 Ex:
 ```sql
@@ -193,7 +193,7 @@ Ex:
     null,                            -- is_rls_enabled
     [],                              -- users,
     array['Error 401: Unauthorized'] -- errors
-)::cdc.wal_rls;
+)::realtime.wal_rls;
 ```
 
 ### Error 413: Payload Too Large
@@ -206,12 +206,12 @@ Ex:
     true,                                  -- is_rls_enabled
     [...],                                 -- users,
     array['Error 413: Payload Too Large']  -- errors
-)::cdc.wal_rls;
+)::realtime.wal_rls;
 ```
 
 ## How it Works
 
-Each WAL record is passed into `cdc.apply_rls(jsonb)` which:
+Each WAL record is passed into `realtime.apply_rls(jsonb)` which:
 
 - impersonates each subscribed user by setting `request.jwt.claims` to an object with `sub` (user's id), `email` (user's email), and `role` ('authenticated')
 - queries for the row using its primary key values
@@ -246,7 +246,7 @@ from
         'write-in-chunks', 'true',
         'format-version', '2',
         'actions', 'insert,update,delete,truncate',
-        'filter-tables', 'cdc.*'
+        'filter-tables', 'realtime.*'
     ),
     lateral (
         select
@@ -255,7 +255,7 @@ from
             x.users,
             x.errors
         from
-            cdc.apply_rls(data::jsonb) x(wal, is_rls_enabled, users, errors)
+            realtime.apply_rls(data::jsonb) x(wal, is_rls_enabled, users, errors)
     ) xyz
 ```
 
@@ -273,7 +273,7 @@ with pub as (
             case when bool_or(pubdelete) then 'delete' else null end,
             case when bool_or(pubtruncate) then 'truncate' else null end
         ) as w2j_actions,
-        string_agg(cdc.quote_wal2json(format('%I.%I', schemaname, tablename)::regclass), ',') w2j_add_tables
+        string_agg(realtime.quote_wal2json(format('%I.%I', schemaname, tablename)::regclass), ',') w2j_add_tables
     from
         pg_publication pp
         join pg_publication_tables ppt
@@ -313,7 +313,7 @@ from
             x.users,
             x.errors
         from
-            cdc.apply_rls(
+            realtime.apply_rls(
                 wal := w2j.data::jsonb,
                 max_record_bytes := 1048576
             ) x(wal, is_rls_enabled, users, errors)
@@ -330,7 +330,7 @@ where
 
 Ex:
 ```sql
-cdc.apply_rls(wal := w2j.data::jsonb, max_record_bytes := 1024*1024) x(wal, is_rls_enabled, users, errors)
+realtime.apply_rls(wal := w2j.data::jsonb, max_record_bytes := 1024*1024) x(wal, is_rls_enabled, users, errors)
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ from
             realtime.apply_rls(data::jsonb) x(wal, is_rls_enabled, subcription_ids, errors)
     ) xyz
 where
-    array_length(xyz.subscription_ids, 1) > 0
+    xyz.subscription_ids[1] is not null
 ```
 
 Or, if the stream should be filtered according to a publication:
@@ -310,7 +310,7 @@ from
     ) xyz
 where
     coalesce(pub.w2j_add_tables, '') <> ''
-    and array_length(xyz.subscription_ids, 1) > 0
+    and xyz.subscription_ids[1] is not null
 ```
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ create table realtime.subscription (
     entity regclass not null,
     filters realtime.user_defined_filter[] not null default '{}',
     claims jsonb not null,
-    claims_role regrole generated always as (realtime.to_regrole(claims ->> 'role')) stored,
+    claims_role regrole not null generated always as (realtime.to_regrole(claims ->> 'role')) stored,
     created_at timestamp not null default timezone('utc', now())
 );
 ```
@@ -173,7 +173,7 @@ Ex:
 ```
 
 ### Error 401: Unauthorized
-If a WAL record is passed through `realtime.apply_rls` and the `authenticated` role does not have permission to `select` the primary key columns in that table, an `Unauthorized` error is returned with no WAL data.
+If a WAL record is passed through `realtime.apply_rls` and the subscription's `clams_role` does not have permission to `select` the primary key columns in that table, an `Unauthorized` error is returned with no WAL data.
 
 Ex:
 ```sql

--- a/README.md
+++ b/README.md
@@ -151,30 +151,6 @@ deletes:
 }
 ```
 
-and truncates
-```json
-{
-    "type": "TRUNCATE",
-    "schema": "public",
-    "table": "todos",
-    "columns": [
-        {
-            "name": "id",
-            "type": "int8",
-        },
-        {
-            "name": "details",
-            "type": "text",
-        },
-        {
-            "name": "user_id",
-            "type": "int8",
-        }
-    ],
-    "commit_timestamp": "2021-09-29T17:35:38Z"
-}
-```
-
 Important Notes:
 
 - Row level security is not applied to delete statements
@@ -245,7 +221,7 @@ from
         'include-timestamp', 'true',
         'write-in-chunks', 'true',
         'format-version', '2',
-        'actions', 'insert,update,delete,truncate',
+        'actions', 'insert,update,delete',
         'filter-tables', 'realtime.*'
     ),
     lateral (
@@ -270,8 +246,7 @@ with pub as (
             ',',
             case when bool_or(pubinsert) then 'insert' else null end,
             case when bool_or(pubupdate) then 'update' else null end,
-            case when bool_or(pubdelete) then 'delete' else null end,
-            case when bool_or(pubtruncate) then 'truncate' else null end
+            case when bool_or(pubdelete) then 'delete' else null end
         ) as w2j_actions,
         string_agg(realtime.quote_wal2json(format('%I.%I', schemaname, tablename)::regclass), ',') w2j_add_tables
     from

--- a/README.md
+++ b/README.md
@@ -159,8 +159,21 @@ Important Notes:
 
 ## Error States
 
+### Error 400: Bad Request, no primary key
+If a WAL record for a table that does not have a primary key is passed through `realtime.apply_rls`, an error is returned
+
+Ex:
+```sql
+(
+    null,                            -- wal
+    null,                            -- is_rls_enabled
+    [],                              -- users,
+    array['Error 400: Bad Request, no primary key'] -- errors
+)::realtime.wal_rls;
+```
+
 ### Error 401: Unauthorized
-If a WAL record is passed through `realtime.apply_rls` and the `authenticated` role does not have permission to `select` any of the columns in that table, an `Unauthorized` error is returned with no WAL data.
+If a WAL record is passed through `realtime.apply_rls` and the `authenticated` role does not have permission to `select` the primary key columns in that table, an `Unauthorized` error is returned with no WAL data.
 
 Ex:
 ```sql

--- a/README.md
+++ b/README.md
@@ -24,12 +24,15 @@ User subscriptions are managed through a table
 
 ```sql
 create table realtime.subscription (
-    id uuid primary key,
+    id bigint generated always as identity primary key,
+    subscription_id uuid not null,
     entity regclass not null,
     filters realtime.user_defined_filter[] not null default '{}',
     claims jsonb not null,
     claims_role regrole not null generated always as (realtime.to_regrole(claims ->> 'role')) stored,
-    created_at timestamp not null default timezone('utc', now())
+    created_at timestamp not null default timezone('utc', now()),
+
+    unique (subscription_id, entity, filters)
 );
 ```
 where `realtime.user_defined_filter` is
@@ -49,7 +52,7 @@ create type realtime.equality_op as enum(
 
 For example, to subscribe to a table named `public.notes` where the `id` is `6` as the `authenticated` role:
 ```sql
-insert into realtime.subscription(id, entity, filters, claims)
+insert into realtime.subscription(subscription_id, entity, filters, claims)
 values ('832bd278-dac7-4bef-96be-e21c8a0023c4', 'public.notes', array[('id', 'eq', '6')], '{"role", "authenticated"}');
 ```
 

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Ex:
 (
     null,                            -- wal
     true,                            -- is_rls_enabled
-    [...],                              -- users,
+    [...],                           -- subscription_ids,
     array['Error 400: Bad Request, no primary key'] -- errors
 )::realtime.wal_rls;
 ```
@@ -180,7 +180,7 @@ Ex:
 (
     null,                            -- wal
     true,                            -- is_rls_enabled
-    [...],                              -- users,
+    [...],                           -- subscription_ids,
     array['Error 401: Unauthorized'] -- errors
 )::realtime.wal_rls;
 ```
@@ -193,7 +193,7 @@ Ex:
 (
     {..., "record": {}, "old_record": {}}, -- wal
     true,                                  -- is_rls_enabled
-    [...],                                 -- users,
+    [...],                                 -- subscription_ids,
     array['Error 413: Payload Too Large']  -- errors
 )::realtime.wal_rls;
 ```
@@ -202,10 +202,10 @@ Ex:
 
 Each WAL record is passed into `realtime.apply_rls(jsonb)` which:
 
-- impersonates each subscribed user by setting `request.jwt.claims` to an object with `sub` (user's id), `email` (user's email), and `role` ('authenticated')
+- impersonates each subscribed user by setting the appropriate role and `request.jwt.claims` that RLS policies depend on
 - queries for the row using its primary key values
 - applies the subscription's filters to check if the WAL record is filtered out
-- filters out all columns that are not visible to the `authenticated` role
+- filters out all columns that are not visible to the user's role
 
 ## Usage
 

--- a/sql/walrus--0.1.sql
+++ b/sql/walrus--0.1.sql
@@ -12,7 +12,7 @@ create type realtime.equality_op as enum(
 );
 
 
-create type realtime.action as enum ('INSERT', 'UPDATE', 'DELETE', 'TRUNCATE', 'ERROR');
+create type realtime.action as enum ('INSERT', 'UPDATE', 'DELETE', 'ERROR');
 
 
 create function realtime.cast(val text, type_ regtype)
@@ -284,7 +284,6 @@ declare
             when 'I' then 'INSERT'
             when 'U' then 'UPDATE'
             when 'D' then 'DELETE'
-            when 'T' then 'TRUNCATE'
             else 'ERROR'
         end
     );

--- a/sql/walrus--0.1.sql
+++ b/sql/walrus--0.1.sql
@@ -50,7 +50,7 @@ create table realtime.subscription (
     entity regclass not null,
     filters realtime.user_defined_filter[] not null default '{}',
     claims jsonb not null,
-    claims_role regrole generated always as (realtime.to_regrole(claims ->> 'role')) stored,
+    claims_role regrole not null generated always as (realtime.to_regrole(claims ->> 'role')) stored,
     created_at timestamp not null default timezone('utc', now())
 );
 create index ix_realtime_subscription_entity on realtime.subscription using hash (entity);

--- a/sql/walrus--0.1.sql
+++ b/sql/walrus--0.1.sql
@@ -4,7 +4,6 @@
 */
 
 create schema realtime;
-grant usage on schema realtime to postgres;
 
 
 create type realtime.equality_op as enum(
@@ -106,9 +105,6 @@ create trigger tr_check_filters
     before insert or update on realtime.subscription
     for each row
     execute function realtime.subscription_check_filters();
-
-
-grant all on realtime.subscription to postgres;
 
 
 create or replace function realtime.quote_wal2json(entity regclass)

--- a/sql/walrus--0.1.sql
+++ b/sql/walrus--0.1.sql
@@ -3,20 +3,20 @@
         Write Ahead Log Realtime Unified Security
 */
 
-create schema cdc;
-grant usage on schema cdc to postgres;
-grant usage on schema cdc to authenticated;
+create schema realtime;
+grant usage on schema realtime to postgres;
+grant usage on schema realtime to authenticated;
 
 
-create type cdc.equality_op as enum(
+create type realtime.equality_op as enum(
     'eq', 'neq', 'lt', 'lte', 'gt', 'gte'
 );
 
 
-create type cdc.action as enum ('INSERT', 'UPDATE', 'DELETE', 'TRUNCATE', 'ERROR');
+create type realtime.action as enum ('INSERT', 'UPDATE', 'DELETE', 'TRUNCATE', 'ERROR');
 
 
-create function cdc.cast(val text, type_ regtype)
+create function realtime.cast(val text, type_ regtype)
     returns jsonb
     immutable
     language plpgsql
@@ -30,30 +30,30 @@ end
 $$;
 
 
-create type cdc.user_defined_filter as (
+create type realtime.user_defined_filter as (
     column_name text,
-    op cdc.equality_op,
+    op realtime.equality_op,
     value text
 );
 
 
-create table cdc.subscription (
+create table realtime.subscription (
     -- Tracks which users are subscribed to each table
     id bigint not null generated always as identity,
     user_id uuid not null,
     -- Populated automatically by trigger. Required to enable auth.email()
     email varchar(255),
     entity regclass not null,
-    filters cdc.user_defined_filter[] not null default '{}',
+    filters realtime.user_defined_filter[] not null default '{}',
     created_at timestamp not null default timezone('utc', now()),
 
     constraint pk_subscription primary key (id),
     unique (entity, user_id, filters)
 );
-create index ix_cdc_subscription_entity on cdc.subscription using hash (entity);
+create index ix_realtime_subscription_entity on realtime.subscription using hash (entity);
 
 
-create function cdc.subscription_check_filters()
+create function realtime.subscription_check_filters()
     returns trigger
     language plpgsql
 as $$
@@ -72,7 +72,7 @@ declare
         where
             (quote_ident(c.table_schema) || '.' || quote_ident(c.table_name))::regclass = new.entity
             and pg_catalog.has_column_privilege('authenticated', new.entity, c.column_name, 'SELECT');
-    filter cdc.user_defined_filter;
+    filter realtime.user_defined_filter;
     col_type regtype;
 begin
     for filter in select * from unnest(new.filters) loop
@@ -92,7 +92,7 @@ begin
             raise exception 'failed to lookup type for column %', filter.column_name;
         end if;
         -- raises an exception if value is not coercable to type
-        perform cdc.cast(filter.value, col_type);
+        perform realtime.cast(filter.value, col_type);
     end loop;
 
     -- Apply consistent order to filters so the unique constraint on
@@ -107,16 +107,16 @@ end;
 $$;
 
 create trigger tr_check_filters
-    before insert or update on cdc.subscription
+    before insert or update on realtime.subscription
     for each row
-    execute function cdc.subscription_check_filters();
+    execute function realtime.subscription_check_filters();
 
 
-grant all on cdc.subscription to postgres;
-grant select on cdc.subscription to authenticated;
+grant all on realtime.subscription to postgres;
+grant select on realtime.subscription to authenticated;
 
 
-create or replace function cdc.quote_wal2json(entity regclass)
+create or replace function realtime.quote_wal2json(entity regclass)
     returns text
     language sql
     immutable
@@ -153,8 +153,8 @@ as $$
 $$;
 
 
-create or replace function cdc.check_equality_op(
-    op cdc.equality_op,
+create or replace function realtime.check_equality_op(
+    op realtime.equality_op,
     type_ regtype,
     val_1 text,
     val_2 text
@@ -186,7 +186,7 @@ end;
 $$;
 
 
-create type cdc.wal_column as (
+create type realtime.wal_column as (
     name text,
     type text,
     value jsonb,
@@ -194,10 +194,10 @@ create type cdc.wal_column as (
     is_selectable boolean
 );
 
-create or replace function cdc.build_prepared_statement_sql(
+create or replace function realtime.build_prepared_statement_sql(
     prepared_statement_name text,
     entity regclass,
-    columns cdc.wal_column[]
+    columns realtime.wal_column[]
 )
     returns text
     language sql
@@ -207,7 +207,7 @@ Builds a sql string that, if executed, creates a prepared statement to
 tests retrive a row from *entity* by its primary key columns.
 
 Example
-    select cdc.build_prepared_statment_sql('public.notes', '{"id"}'::text[], '{"bigint"}'::text[])
+    select realtime.build_prepared_statment_sql('public.notes', '{"id"}'::text[], '{"bigint"}'::text[])
 */
     select
 'prepare ' || prepared_statement_name || ' as
@@ -229,7 +229,7 @@ Example
 $$;
 
 
-create type cdc.wal_rls as (
+create type realtime.wal_rls as (
     wal jsonb,
     is_rls_enabled boolean,
     users uuid[],
@@ -238,7 +238,7 @@ create type cdc.wal_rls as (
 
 
 
-create or replace function cdc.is_visible_through_filters(columns cdc.wal_column[], filters cdc.user_defined_filter[])
+create or replace function realtime.is_visible_through_filters(columns realtime.wal_column[], filters realtime.user_defined_filter[])
     returns bool
     language sql
     immutable
@@ -250,7 +250,7 @@ Should the record be visible (true) or filtered out (false) after *filters* are 
         -- Default to allowed when no filters present
         coalesce(
             sum(
-                cdc.check_equality_op(
+                realtime.check_equality_op(
                     op:=f.op,
                     type_:=col.type::regtype,
                     -- cast jsonb to text
@@ -267,8 +267,8 @@ Should the record be visible (true) or filtered out (false) after *filters* are 
 $$;
 
 
-create or replace function cdc.apply_rls(wal jsonb, max_record_bytes int = 1024 * 1024)
-    returns cdc.wal_rls
+create or replace function realtime.apply_rls(wal jsonb, max_record_bytes int = 1024 * 1024)
+    returns realtime.wal_rls
     language plpgsql
     volatile
 as $$
@@ -277,7 +277,7 @@ declare
     entity_ regclass = (quote_ident(wal ->> 'schema') || '.' || quote_ident(wal ->> 'table'))::regclass;
 
     -- I, U, D, T: insert, update ...
-    action cdc.action = (
+    action realtime.action = (
         case wal ->> 'action'
             when 'I' then 'INSERT'
             when 'U' then 'UPDATE'
@@ -298,23 +298,23 @@ declare
     visible_to_user_ids uuid[] = '{}';
 
     -- user subscriptions to the wal record's table
-    subscriptions cdc.subscription[] =
+    subscriptions realtime.subscription[] =
             array_agg(sub)
         from
-            cdc.subscription sub
+            realtime.subscription sub
         where
             sub.entity = entity_;
 
     -- structured info for wal's columns
-    columns cdc.wal_column[] =
+    columns realtime.wal_column[] =
         array_agg(
             (
                 x->>'name',
                 x->>'type',
-                cdc.cast((x->'value') #>> '{}', (x->>'type')::regtype),
+                realtime.cast((x->'value') #>> '{}', (x->>'type')::regtype),
                 (pks ->> 'name') is not null,
                 pg_catalog.has_column_privilege('authenticated', entity_, x->>'name', 'SELECT')
-            )::cdc.wal_column
+            )::realtime.wal_column
         )
         from
             jsonb_array_elements(wal -> 'columns') x
@@ -322,15 +322,15 @@ declare
                 on (x ->> 'name') = (pks ->> 'name');
 
     -- previous identity values for update/delete
-    old_columns cdc.wal_column[] =
+    old_columns realtime.wal_column[] =
         array_agg(
             (
                 x->>'name',
                 x->>'type',
-                cdc.cast((x->'value') #>> '{}', (x->>'type')::regtype),
+                realtime.cast((x->'value') #>> '{}', (x->>'type')::regtype),
                 (pks ->> 'name') is not null,
                 pg_catalog.has_column_privilege('authenticated', entity_, x->>'name', 'SELECT')
-            )::cdc.wal_column
+            )::realtime.wal_column
         )
         from
             jsonb_array_elements(wal -> 'identity') x
@@ -356,7 +356,7 @@ begin
             null,
             visible_to_user_ids,
             array['Error 401: Unauthorized']
-        )::cdc.wal_rls;
+        )::realtime.wal_rls;
     end if;
 
     -------------------------------
@@ -416,7 +416,7 @@ begin
             if (select 1 from pg_prepared_statements where name = 'walrus_rls_stmt' limit 1) > 0 then
                 deallocate walrus_rls_stmt;
             end if;
-            execute cdc.build_prepared_statement_sql('walrus_rls_stmt', entity_, columns);
+            execute realtime.build_prepared_statement_sql('walrus_rls_stmt', entity_, columns);
 
         end if;
 
@@ -425,7 +425,7 @@ begin
                 select
                     subs.user_id,
                     subs.email,
-                    cdc.is_visible_through_filters(columns, subs.filters)
+                    realtime.is_visible_through_filters(columns, subs.filters)
                 from
                     unnest(subscriptions) subs
         )
@@ -467,6 +467,6 @@ begin
         is_rls_enabled,
         visible_to_user_ids,
         errors
-    )::cdc.wal_rls;
+    )::realtime.wal_rls;
 end;
 $$;

--- a/sql/walrus--0.1.sql
+++ b/sql/walrus--0.1.sql
@@ -98,13 +98,6 @@ begin
         perform realtime.cast(filter.value, col_type);
     end loop;
 
-    -- Apply consistent order to filters so the unique constraint on
-    -- (subscription_id, entity, filters) can't be tricked by a different filter order
-    new.filters = coalesce(
-        array_agg(f order by f.column_name, f.op, f.value),
-        '{}'
-    ) from unnest(new.filters) f;
-
     return new;
 end;
 $$;

--- a/sql/walrus--0.1.sql
+++ b/sql/walrus--0.1.sql
@@ -389,7 +389,7 @@ begin
         if action <> 'DELETE' and count(1) = 0 from unnest(columns) c where c.is_pkey then
             result_arr = result_arr || (
                 null,
-                null,
+                is_rls_enabled,
                 (select array_agg(id) from realtime.subscription where entity = entity_ and claims_role = working_role),
                 array['Error 400: Bad Request, no primary key']
             )::realtime.wal_rls;
@@ -398,7 +398,7 @@ begin
         elsif action <> 'DELETE' and sum(c.is_selectable::int) <> count(1) from unnest(columns) c where c.is_pkey then
             result_arr = result_arr || (
                 null,
-                null,
+                is_rls_enabled,
                 (select array_agg(id) from realtime.subscription where entity = entity_ and claims_role = working_role),
                 array['Error 401: Unauthorized']
             )::realtime.wal_rls;

--- a/sql/walrus--0.1.sql
+++ b/sql/walrus--0.1.sql
@@ -5,7 +5,6 @@
 
 create schema realtime;
 grant usage on schema realtime to postgres;
-grant usage on schema realtime to authenticated;
 
 
 create type realtime.equality_op as enum(
@@ -37,18 +36,22 @@ create type realtime.user_defined_filter as (
 );
 
 
+create function realtime.to_regrole(role_name text)
+    returns regrole
+    immutable
+    language sql
+    -- required to allow use in generated clause
+as $$ select role_name::regrole $$;
+
+
 create table realtime.subscription (
     -- Tracks which users are subscribed to each table
-    id bigint not null generated always as identity,
-    user_id uuid not null,
-    -- Populated automatically by trigger. Required to enable auth.email()
-    email varchar(255),
+    id uuid primary key,
     entity regclass not null,
     filters realtime.user_defined_filter[] not null default '{}',
-    created_at timestamp not null default timezone('utc', now()),
-
-    constraint pk_subscription primary key (id),
-    unique (entity, user_id, filters)
+    claims jsonb not null,
+    claims_role regrole generated always as (realtime.to_regrole(claims ->> 'role')) stored,
+    created_at timestamp not null default timezone('utc', now())
 );
 create index ix_realtime_subscription_entity on realtime.subscription using hash (entity);
 
@@ -59,7 +62,7 @@ create function realtime.subscription_check_filters()
 as $$
 /*
 Validates that the user defined filters for a subscription:
-- refer to valid columns that "authenticated" may access
+- refer to valid columns that the claimed role may access
 - values are coercable to the correct column type
 */
 declare
@@ -70,8 +73,8 @@ declare
         from
             information_schema.columns c
         where
-            (quote_ident(c.table_schema) || '.' || quote_ident(c.table_name))::regclass = new.entity
-            and pg_catalog.has_column_privilege('authenticated', new.entity, c.column_name, 'SELECT');
+            format('%I.%I', c.table_schema, c.table_name)::regclass = new.entity
+            and pg_catalog.has_column_privilege(new.claims_role, new.entity, c.column_name, 'SELECT');
     filter realtime.user_defined_filter;
     col_type regtype;
 begin
@@ -113,7 +116,6 @@ create trigger tr_check_filters
 
 
 grant all on realtime.subscription to postgres;
-grant select on realtime.subscription to authenticated;
 
 
 create or replace function realtime.quote_wal2json(entity regclass)
@@ -268,7 +270,7 @@ $$;
 
 
 create or replace function realtime.apply_rls(wal jsonb, max_record_bytes int = 1024 * 1024)
-    returns realtime.wal_rls
+    returns setof realtime.wal_rls
     language plpgsql
     volatile
 as $$
@@ -291,182 +293,187 @@ declare
     is_rls_enabled bool = relrowsecurity from pg_class where oid = entity_;
 
     -- Subscription vars
-    user_id uuid;
-    email varchar(255);
-    user_has_access bool;
-    is_visible_to_user boolean;
-    visible_to_user_ids uuid[] = '{}';
-
-    -- user subscriptions to the wal record's table
-    subscriptions realtime.subscription[] =
-            array_agg(sub)
+    roles regrole[] = array_agg(distinct claims_role)
         from
-            realtime.subscription sub
+            realtime.subscription
         where
-            sub.entity = entity_;
+            entity = entity_;
+
+    working_role regrole;
+    claimed_role regrole;
+    claims jsonb;
+
+    subscriptions realtime.subscription[] = array_agg(subs)
+        from
+            realtime.subscription subs
+        where
+            subs.entity = entity_;
+
+    subscription_id uuid;
+    subscription_has_access bool;
+    visible_to_subscription_ids uuid[] = '{}';
 
     -- structured info for wal's columns
-    columns realtime.wal_column[] =
-        array_agg(
-            (
-                x->>'name',
-                x->>'type',
-                realtime.cast((x->'value') #>> '{}', (x->>'type')::regtype),
-                (pks ->> 'name') is not null,
-                pg_catalog.has_column_privilege('authenticated', entity_, x->>'name', 'SELECT')
-            )::realtime.wal_column
-        )
-        from
-            jsonb_array_elements(wal -> 'columns') x
-            left join jsonb_array_elements(wal -> 'pk') pks
-                on (x ->> 'name') = (pks ->> 'name');
-
+    columns realtime.wal_column[];
     -- previous identity values for update/delete
-    old_columns realtime.wal_column[] =
-        array_agg(
-            (
-                x->>'name',
-                x->>'type',
-                realtime.cast((x->'value') #>> '{}', (x->>'type')::regtype),
-                (pks ->> 'name') is not null,
-                pg_catalog.has_column_privilege('authenticated', entity_, x->>'name', 'SELECT')
-            )::realtime.wal_column
-        )
-        from
-            jsonb_array_elements(wal -> 'identity') x
-            left join jsonb_array_elements(wal -> 'pk') pks
-                on (x ->> 'name') = (pks ->> 'name');
-
-    output jsonb;
+    old_columns realtime.wal_column[];
 
     -- Error states
     error_record_exceeds_max_size boolean = octet_length(wal::text) > max_record_bytes;
-    error_unauthorized boolean = not pg_catalog.has_any_column_privilege('authenticated', entity_, 'SELECT');
+    error_primary_key_not_selectable boolean; -- todo
+    errors text[];
 
-    errors text[] = case
-        when error_record_exceeds_max_size then array['Error 413: Payload Too Large']
-        else '{}'::text[]
-    end;
+    -- Primary jsonb output for record
+    output jsonb;
+
+    -- Final response
+    result_arr realtime.wal_rls[] = '{}';
 begin
+    perform set_config('role', null, true);
 
-    -- The 'authenticated' user does not have SELECT permission on any of the columns for the entity_
-    if error_unauthorized is true then
-        return (
-            null,
-            null,
-            visible_to_user_ids,
-            array['Error 401: Unauthorized']
-        )::realtime.wal_rls;
-    end if;
+    for working_role in select * from unnest(roles) loop
 
-    -------------------------------
-    -- Build Output JSONB Object --
-    -------------------------------
-    output = jsonb_build_object(
-        'schema', wal ->> 'schema',
-        'table', wal ->> 'table',
-        'type', action,
-        'commit_timestamp', (wal ->> 'timestamp')::text::timestamp with time zone,
-        'columns', (
-            select
-                jsonb_agg(
-                    jsonb_build_object(
-                        'name', pa.attname,
-                        'type', pt.typname
-                    )
-                    order by pa.attnum asc
+        errors = '{}';
+        visible_to_subscription_ids = '{}';
+
+
+        -- The claims user does not have SELECT permission on any of the columns for the entity_
+        if not pg_catalog.has_any_column_privilege(working_role, entity_, 'SELECT') then
+            result_arr = result_arr || (
+                null,
+                null,
+                (select array_agg(id) from realtime.subscription where entity = entity_ and claims_role = working_role),
+                array['Error 401: Unauthorized']
+            )::realtime.wal_rls;
+        else
+            columns =
+                array_agg(
+                    (
+                        x->>'name',
+                        x->>'type',
+                        realtime.cast((x->'value') #>> '{}', (x->>'type')::regtype),
+                        (pks ->> 'name') is not null,
+                        pg_catalog.has_column_privilege(working_role, entity_, x->>'name', 'SELECT')
+                    )::realtime.wal_column
                 )
-            from
-                pg_attribute pa
-                join pg_type pt
-                    on pa.atttypid = pt.oid
-            where
-                attrelid = entity_
-                and attnum > 0
-                and pg_catalog.has_column_privilege('authenticated', entity_, pa.attname, 'SELECT')
-        )
-    )
-    -- Add "record" key for insert and update
-    || case
-        when error_record_exceeds_max_size then jsonb_build_object('record', '{}'::jsonb)
-        when action in ('INSERT', 'UPDATE') then
-            jsonb_build_object(
-                'record',
-                (select jsonb_object_agg((c).name, (c).value) from unnest(columns) c where (c).is_selectable)
-            )
-        else '{}'::jsonb
-    end
-    -- Add "old_record" key for update and delete
-    || case
-        when error_record_exceeds_max_size then jsonb_build_object('old_record', '{}'::jsonb)
-        when action in ('UPDATE', 'DELETE') then
-            jsonb_build_object(
-                'old_record',
-                (select jsonb_object_agg((c).name, (c).value) from unnest(old_columns) c where (c).is_selectable)
-            )
-        else '{}'::jsonb
-    end;
-
-    if action in ('TRUNCATE', 'DELETE') then
-        visible_to_user_ids = array_agg(s.user_id) from unnest(subscriptions) s;
-    else
-        -- If RLS is on and someone is subscribed to the table prep
-        if is_rls_enabled and array_length(subscriptions, 1) > 0 then
-            perform set_config('role', 'authenticated', true);
-            if (select 1 from pg_prepared_statements where name = 'walrus_rls_stmt' limit 1) > 0 then
-                deallocate walrus_rls_stmt;
-            end if;
-            execute realtime.build_prepared_statement_sql('walrus_rls_stmt', entity_, columns);
-
-        end if;
-
-        -- For each subscribed user
-        for user_id, email, is_visible_to_user in (
-                select
-                    subs.user_id,
-                    subs.email,
-                    realtime.is_visible_through_filters(columns, subs.filters)
                 from
-                    unnest(subscriptions) subs
-        )
-        loop
-            if is_visible_to_user then
-                -- If RLS is off, add to visible users
-                if not is_rls_enabled then
-                    visible_to_user_ids = visible_to_user_ids || user_id;
+                    jsonb_array_elements(wal -> 'columns') x
+                    left join jsonb_array_elements(wal -> 'pk') pks
+                        on (x ->> 'name') = (pks ->> 'name');
+
+            old_columns =
+                array_agg(
+                    (
+                        x->>'name',
+                        x->>'type',
+                        realtime.cast((x->'value') #>> '{}', (x->>'type')::regtype),
+                        (pks ->> 'name') is not null,
+                        pg_catalog.has_column_privilege(working_role, entity_, x->>'name', 'SELECT')
+                    )::realtime.wal_column
+                )
+                from
+                    jsonb_array_elements(wal -> 'identity') x
+                    left join jsonb_array_elements(wal -> 'pk') pks
+                        on (x ->> 'name') = (pks ->> 'name');
+
+            output = jsonb_build_object(
+                'schema', wal ->> 'schema',
+                'table', wal ->> 'table',
+                'type', action,
+                'commit_timestamp', (wal ->> 'timestamp')::text::timestamp with time zone,
+                'columns', (
+                    select
+                        jsonb_agg(
+                            jsonb_build_object(
+                                'name', pa.attname,
+                                'type', pt.typname
+                            )
+                            order by pa.attnum asc
+                        )
+                    from
+                        pg_attribute pa
+                        join pg_type pt
+                            on pa.atttypid = pt.oid
+                    where
+                        attrelid = entity_
+                        and attnum > 0
+                        and pg_catalog.has_column_privilege(working_role, entity_, pa.attname, 'SELECT')
+                )
+            )
+            -- Add "record" key for insert and update
+            || case
+                when error_record_exceeds_max_size then jsonb_build_object('record', '{}'::jsonb)
+                when action in ('INSERT', 'UPDATE') then
+                    jsonb_build_object(
+                        'record',
+                        (select jsonb_object_agg((c).name, (c).value) from unnest(columns) c where (c).is_selectable)
+                    )
+                else '{}'::jsonb
+            end
+            -- Add "old_record" key for update and delete
+            || case
+                when error_record_exceeds_max_size then jsonb_build_object('old_record', '{}'::jsonb)
+                when action in ('UPDATE', 'DELETE') then
+                    jsonb_build_object(
+                        'old_record',
+                        (select jsonb_object_agg((c).name, (c).value) from unnest(old_columns) c where (c).is_selectable)
+                    )
+                else '{}'::jsonb
+            end;
+
+            -- TODO: error cases + primary key is selectable
+
+            -- Create the prepared statement
+            if is_rls_enabled then
+                if (select 1 from pg_prepared_statements where name = 'walrus_rls_stmt' limit 1) > 0 then
+                    deallocate walrus_rls_stmt;
+                end if;
+                execute realtime.build_prepared_statement_sql('walrus_rls_stmt', entity_, columns);
+            end if;
+
+            visible_to_subscription_ids = '{}';
+
+            for subscription_id, claims in (
+                    select
+                        subs.id,
+                        subs.claims
+                    from
+                        unnest(subscriptions) subs
+                    where
+                        subs.entity = entity_
+                        and subs.claims_role = working_role
+                        and realtime.is_visible_through_filters(columns, subs.filters)
+            ) loop
+
+                if action = 'DELETE' or not is_rls_enabled then
+                    visible_to_subscription_ids = visible_to_subscription_ids || subscription_id;
                 else
                     -- Check if RLS allows the user to see the record
                     perform
-                        set_config(
-                            'request.jwt.claims',
-                            jsonb_build_object(
-                                'sub', user_id::text,
-                                'email', email::text,
-                                'role', 'authenticated'
-                            )::text,
-                            true
-                        );
-                    execute 'execute walrus_rls_stmt' into user_has_access;
+                        set_config('role', working_role::text, true),
+                        set_config('request.jwt.claims', claims::text, true);
 
-                    if user_has_access then
-                        visible_to_user_ids = visible_to_user_ids || user_id;
+                    execute 'execute walrus_rls_stmt' into subscription_has_access;
+
+                    if subscription_has_access then
+                        visible_to_subscription_ids = visible_to_subscription_ids || subscription_id;
                     end if;
-
                 end if;
-            end if;
-        end loop;
+            end loop;
 
-        perform (
-            set_config('role', null, true)
-        );
+            perform set_config('role', null, true);
 
-    end if;
+            result_arr = result_arr || (
+                output,
+                is_rls_enabled,
+                visible_to_subscription_ids,
+                errors
+            )::realtime.wal_rls;
 
-    return (
-        output,
-        is_rls_enabled,
-        visible_to_user_ids,
-        errors
-    )::realtime.wal_rls;
+        end if;
+    end loop;
+
+
+    return next unnest(result_arr);
 end;
 $$;

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -80,7 +80,7 @@ for table
     public.note,
     public.unauthorized
 with (
-    publish = 'insert,update,delete,truncate'
+    publish = 'insert,update,delete'
 );
             """
         )

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -121,7 +121,7 @@ select * from pg_create_logical_replication_slot('realtime', 'wal2json', false);
     alter default privileges in schema public grant all on tables to authenticated;
     alter default privileges in schema public grant all on functions to authenticated;
     alter default privileges in schema public grant all on sequences to authenticated;
-    truncate table cdc.subscription cascade;
+    truncate table realtime.subscription cascade;
     """
     )
     conn.execute(text("commit"))

--- a/test/test_slot.py
+++ b/test/test_slot.py
@@ -49,11 +49,6 @@ class DeleteWAL(BaseWAL):
     old_record: ColValDict
 
 
-class TruncateWAL(BaseWAL):
-    type: Literal["TRUNCATE"]
-    columns: Columns
-
-
 class InsertWAL(BaseWAL):
     type: Literal["INSERT"]
     columns: Columns

--- a/test/test_slot.py
+++ b/test/test_slot.py
@@ -404,7 +404,10 @@ select
     extensions.uuid_generate_v4(),
     'public.note',
     array[{filter_str}]::realtime.user_defined_filter[],
-    jsonb_build_object('role', 'authenticated');
+    jsonb_build_object(
+        'role', 'authenticated',
+        'sub', extensions.uuid_generate_v4()::text
+    );
     """
     )
     sess.commit()

--- a/test/test_slot.py
+++ b/test/test_slot.py
@@ -120,7 +120,7 @@ from
     ) xyz
 where
     coalesce(pub.w2j_add_tables, '') <> ''
-    and array_length(xyz.subscription_ids, 1) > 0
+    and xyz.subscription_ids[1] is not null
 """
 )
 

--- a/test/test_slot.py
+++ b/test/test_slot.py
@@ -165,7 +165,7 @@ def insert_subscriptions(sess, role: str = "authenticated", n=1):
     sess.execute(
         text(
             """
-insert into realtime.subscription(id, entity, claims)
+insert into realtime.subscription(subscription_id, entity, claims)
 select
     extensions.uuid_generate_v4(),
     'public.note',
@@ -267,7 +267,7 @@ revoke select on public.unauthorized from authenticated;
     sess.execute(
         text(
             """
-insert into realtime.subscription(id, entity, claims)
+insert into realtime.subscription(subscription_id, entity, claims)
 select extensions.uuid_generate_v4(), 'public.unauthorized', jsonb_build_object('role', 'authenticated');
     """
         )
@@ -465,7 +465,7 @@ def test_user_defined_eq_filter(filter_str, is_true, sess):
     # Test does not match
     sess.execute(
         f"""
-insert into realtime.subscription(id, entity, filters, claims)
+insert into realtime.subscription(subscription_id, entity, filters, claims)
 select
     extensions.uuid_generate_v4(),
     'public.note',

--- a/test/test_slot.py
+++ b/test/test_slot.py
@@ -75,8 +75,7 @@ with pub as (
             ',',
             case when bool_or(pubinsert) then 'insert' else null end,
             case when bool_or(pubupdate) then 'update' else null end,
-            case when bool_or(pubdelete) then 'delete' else null end,
-            case when bool_or(pubtruncate) then 'truncate' else null end
+            case when bool_or(pubdelete) then 'delete' else null end
         ) as w2j_actions,
         string_agg(realtime.quote_wal2json(format('%I.%I', schemaname, tablename)::regclass), ',') w2j_add_tables
     from
@@ -333,21 +332,6 @@ def test_wal_update_changed_identity(sess):
     assert wal["record"]["id"] == 99
     assert wal["record"]["body"] == "some body"
     assert wal["old_record"]["id"] == 1
-
-
-def test_wal_truncate(sess):
-    setup_note(sess)
-    setup_note_rls(sess)
-    insert_subscriptions(sess, n=2)
-    insert_notes(sess, n=1)
-    clear_wal(sess)
-    sess.execute("truncate table public.note;")
-    sess.commit()
-    _, wal, is_rls_enabled, users, errors = sess.execute(QUERY).one()
-    TruncateWAL.parse_obj(wal)
-    assert errors == []
-    assert is_rls_enabled
-    assert len(users) == 2
 
 
 def test_wal_delete(sess):

--- a/test/test_user_defined_filters.py
+++ b/test/test_user_defined_filters.py
@@ -46,7 +46,7 @@ def test_user_defined_eq_filter(op, type_, val_1, val_2, result, sess):
     (x,) = sess.execute(
         select(
             [
-                func.cdc.check_equality_op(
+                func.realtime.check_equality_op(
                     op,
                     type_,
                     val_1,


### PR DESCRIPTION
## What kind of change does this PR introduce?
- Removes hard coded use of `authenticated` role
- Replaces `realtime.subscription` email, and role fields with generic jwt claims jsonb field

at minimum, that the claims must contain a top level key named role e.g. `{"role": "authenticated"}`, which is verified by a trigger to be a valid role at the time the subscription is made.

- Since multiple subscribers may have different roles, and therefore different column access, the `realtime.apply_rls()` function now returns `setof realtime.wal_rls` instead of `realtime.wal_rls`

- The `Unauthorized` exception has been expanded from being raised when a role can not access any columns on a table to being raised if any of the primary key columns can not be selected by the role

- A `Bad Request` error was added and is thrown when the WAL record's table has no primary key (replaces #28)

- When errors are returned, the `subscription_ids` are return so users can be notified as needed




