### PR TITLE
Hacky (temporary) fix to invalid type name escapes. fixes #31

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,9 @@ from
             x.subscription_ids,
             x.errors
         from
-            realtime.apply_rls(data::jsonb) x(wal, is_rls_enabled, subcription_ids, errors)
+            realtime.apply_rls(
+                wal := realtime.bugfix_w2j_typenames(data)::jsonb,
+            ) x(wal, is_rls_enabled, subcription_ids, errors)
     ) xyz
 where
     xyz.subscription_ids[1] is not null
@@ -307,7 +309,7 @@ select
 from
     w2j,
     realtime.apply_rls(
-        wal := w2j.data::jsonb,
+        wal := realtime.bugfix_w2j_typenames(w2j.data)::jsonb,
         max_record_bytes := 1048576
     ) xyz(wal, is_rls_enabled, subscription_ids, errors)
 where

--- a/test/test_bugfix_w2j_typenames.py
+++ b/test/test_bugfix_w2j_typenames.py
@@ -1,0 +1,16 @@
+import pytest
+from sqlalchemy import func, select
+
+
+@pytest.mark.parametrize(
+    "input_,output_",
+    [
+        (
+            """[{"name":"id","type":"bigint","value":1},{"name":"mood","type":""MOOD"","value":"happy"}, {"name":"mood","type":""aB3c D"","value":"happy"}""",
+            """[{"name":"id","type":"bigint","value":1},{"name":"mood","type":"MOOD","value":"happy"}, {"name":"mood","type":"aB3c D","value":"happy"}""",
+        )
+    ],
+)
+def test_bugfix_w2j_typeames(input_: str, output_: str, sess):
+    x = sess.execute(select([func.realtime.bugfix_w2j_typenames(input_)])).scalar_one()
+    assert x == output_

--- a/test/test_slot.py
+++ b/test/test_slot.py
@@ -106,7 +106,7 @@ w2j as (
         ) x
 )
 select
-    w2j.data::jsonb,
+    realtime.bugfix_w2j_typenames(w2j.data)::jsonb,
     xyz.wal,
     xyz.is_rls_enabled,
     xyz.subscription_ids,
@@ -114,7 +114,7 @@ select
 from
     w2j,
     realtime.apply_rls(
-        wal := w2j.data::jsonb,
+        wal := realtime.bugfix_w2j_typenames(w2j.data)::jsonb,
         max_record_bytes := 1048576
     ) xyz(wal, is_rls_enabled, subscription_ids, errors)
 where


### PR DESCRIPTION
Temporary regex + replace fix to correct invalid json output from wal2json format_version 2 when type names require escapes.

For full context see #31 and eulerto/wal2json#224

Known Risks:
- If a type's name contains `"",`, for example, `contrived"",example` the WAL text will not be castable to json