### PR TITLE
Required WAL keys "schema", "table", "type"

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,11 @@ If a WAL record for a table that does not have a primary key is passed through `
 Ex:
 ```sql
 (
-    null,                            -- wal
+    {
+        "type": ...,
+        "schema": ...,
+        "table": ...
+    },                               -- wal
     true,                            -- is_rls_enabled
     [...],                           -- subscription_ids,
     array['Error 400: Bad Request, no primary key'] -- errors
@@ -181,7 +185,11 @@ If a WAL record is passed through `realtime.apply_rls` and the subscription's `c
 Ex:
 ```sql
 (
-    null,                            -- wal
+    {
+        "type": ...,
+        "schema": ...,
+        "table": ...
+    },                               -- wal
     true,                            -- is_rls_enabled
     [...],                           -- subscription_ids,
     array['Error 401: Unauthorized'] -- errors

--- a/sql/walrus--0.1.sql
+++ b/sql/walrus--0.1.sql
@@ -383,7 +383,11 @@ begin
 
         if action <> 'DELETE' and count(1) = 0 from unnest(columns) c where c.is_pkey then
             return next (
-                null,
+                jsonb_build_object(
+                    'schema', wal ->> 'schema',
+                    'table', wal ->> 'table',
+                    'type', action
+                ),
                 is_rls_enabled,
                 -- subscriptions is already filtered by entity
                 (select array_agg(s.subscription_id) from unnest(subscriptions) as s where claims_role = working_role),
@@ -393,7 +397,11 @@ begin
         -- The claims role does not have SELECT permission to the primary key of entity
         elsif action <> 'DELETE' and sum(c.is_selectable::int) <> count(1) from unnest(columns) c where c.is_pkey then
             return next (
-                null,
+                jsonb_build_object(
+                    'schema', wal ->> 'schema',
+                    'table', wal ->> 'table',
+                    'type', action
+                ),
                 is_rls_enabled,
                 (select array_agg(s.subscription_id) from unnest(subscriptions) as s where claims_role = working_role),
                 array['Error 401: Unauthorized']


### PR DESCRIPTION
### New Behavior
Always return "schema" "table" and "type" keys in `wal`, including on errors.

### Old Behavior
When errors are thrown, return `null` for `wal`

### Refs
#33