### PR TITLE
commit_timestamp in ISO8601 zulu format

### DIFF
--- a/sql/walrus--0.1.sql
+++ b/sql/walrus--0.1.sql
@@ -412,7 +412,10 @@ begin
                 'schema', wal ->> 'schema',
                 'table', wal ->> 'table',
                 'type', action,
-                'commit_timestamp', (wal ->> 'timestamp')::text::timestamp with time zone,
+                'commit_timestamp', to_char(
+                    (wal ->> 'timestamp')::timestamptz,
+                    'YYYY-MM-DD"T"HH24:MI:SS"Z"'
+                ),
                 'columns', (
                     select
                         jsonb_agg(

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -32,7 +32,7 @@ def dockerize_database():
         else:
             raise Exception("Container never became healthy")
         yield
-        # subprocess.call(["docker-compose", "down", "-v"])
+        subprocess.call(["docker-compose", "down", "-v"])
         return
     yield
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -32,7 +32,7 @@ def dockerize_database():
         else:
             raise Exception("Container never became healthy")
         yield
-        subprocess.call(["docker-compose", "down", "-v"])
+        # subprocess.call(["docker-compose", "down", "-v"])
         return
     yield
 

--- a/test/test_slot.py
+++ b/test/test_slot.py
@@ -7,10 +7,10 @@ from pydantic import BaseModel, Extra, Field, validator
 from sqlalchemy import text
 
 
-def validate_iso8601(text: str) -> bool:
+def validate_timestamp(text: str) -> bool:
     """Validates a timestamp string matches iso8601 format"""
     # datetime.datetime.fromisoformat does not handle timezones correctly
-    regex = r"^(-?(?:[1-9][0-9]*)?[0-9]{4})-(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12][0-9])T(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])(\.[0-9]+)?(Z|[+-](?:2[0-3]|[01][0-9]):[0-5][0-9])?$"
+    regex = r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$"
     match_iso8601 = re.compile(regex).match
     try:
         if match_iso8601(text) is not None:
@@ -30,7 +30,7 @@ class BaseWAL(BaseModel):
 
     @validator("commit_timestamp")
     def validate_commit_timestamp(cls, v):
-        validate_iso8601(v)
+        validate_timestamp(v)
         return v
 
 


### PR DESCRIPTION
Updates `commit_timestamp` key to use ISO8601 zulu format

resolves #37 