### PR TITLE
Support types that require Quoting

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -51,6 +51,8 @@ def sess(engine):
     conn.execute(
         text(
             """
+create type "MyType" as enum('1');
+
 create table public.note(
     id bigserial primary key,
     user_id uuid not null,
@@ -59,7 +61,7 @@ create table public.note(
     arr_int int[] not null default array[1, 2],
 
     -- dummy column with revoked select for "authenticated"
-    dummy text
+    dummy "MyType"
 
 );
 create index ix_note_user_id on public.note (user_id);

--- a/test/test_user_defined_filters.py
+++ b/test/test_user_defined_filters.py
@@ -40,6 +40,8 @@ from sqlalchemy import func, select
             "b423f213-ac24-402a-95ea-cf1d94d8e9f0",
             False,
         ),
+        # custom quoted type
+        ("eq", "MyType", "1", "1", True),
     ],
 )
 def test_user_defined_eq_filter(op, type_, val_1, val_2, result, sess):
@@ -48,7 +50,7 @@ def test_user_defined_eq_filter(op, type_, val_1, val_2, result, sess):
             [
                 func.realtime.check_equality_op(
                     op,
-                    type_,
+                    func.realtime.parse_regtype(type_),
                     val_1,
                     val_2,
                 )


### PR DESCRIPTION
## What kind of change does this PR introduce?
Fixes a bug where the text representation of types are incorrectly cast to regtype, resulting in runtime exceptions, when the type requires quotes `"`

## What is the current behavior?
Processing a WAL record containing a custom quoted type e.g.
```sql
create type "MyType" as enum('1');

create table xyz(
    id serial primary key,
    x "MyType"
);

insert into xyz(x) values ( '1');
```
results in an error
```sql
message: "type \"mytype\" does not exist"
```

Due to [this](https://github.com/supabase/walrus/compare/cast_regtype?expand=1#diff-bd85ab1223dc61b5379444cf8fbeb7dcaf3c0dc2343a6a6be069ff71ed036ccfL256) approach to casting

## What is the new behavior?
Quoted types can be cast to regclass via [this function](https://github.com/supabase/walrus/compare/cast_regtype?expand=1#diff-bd85ab1223dc61b5379444cf8fbeb7dcaf3c0dc2343a6a6be069ff71ed036ccfR16)

## A Better Fix (Future)
wal2json has a setting called `include-type-oids` that is much easier to work with because it does not require quoting.  Currently, that option is not compatible with `format-version=2`, which is what we use. I [opened an issue at wal2json](https://github.com/eulerto/wal2json/issues/232) asking for it to be ported. If that issue gets traction, we should use the oids instead


closes #40