### PR TITLE
When payload too large, include data for columns <= 64 bytes

### DIFF
--- a/sql/walrus--0.1.sql
+++ b/sql/walrus--0.1.sql
@@ -453,22 +453,44 @@ begin
             )
             -- Add "record" key for insert and update
             || case
-                when error_record_exceeds_max_size then jsonb_build_object('record', '{}'::jsonb)
                 when action in ('INSERT', 'UPDATE') then
-                    jsonb_build_object(
-                        'record',
-                        (select jsonb_object_agg((c).name, (c).value) from unnest(columns) c where (c).is_selectable)
-                    )
+                    case
+                        when error_record_exceeds_max_size then
+                            jsonb_build_object(
+                                'record',
+                                (
+                                    select jsonb_object_agg((c).name, (c).value)
+                                    from unnest(columns) c
+                                    where (c).is_selectable and (octet_length((c).value::text) <= 64)
+                                )
+                            )
+                        else
+                            jsonb_build_object(
+                                'record',
+                                (select jsonb_object_agg((c).name, (c).value) from unnest(columns) c where (c).is_selectable)
+                            )
+                    end
                 else '{}'::jsonb
             end
             -- Add "old_record" key for update and delete
             || case
-                when error_record_exceeds_max_size then jsonb_build_object('old_record', '{}'::jsonb)
                 when action in ('UPDATE', 'DELETE') then
-                    jsonb_build_object(
-                        'old_record',
-                        (select jsonb_object_agg((c).name, (c).value) from unnest(old_columns) c where (c).is_selectable)
-                    )
+                    case
+                        when error_record_exceeds_max_size then
+                            jsonb_build_object(
+                                'old_record',
+                                (
+                                    select jsonb_object_agg((c).name, (c).value)
+                                    from unnest(old_columns) c
+                                    where (c).is_selectable and (octet_length((c).value::text) <= 64)
+                                )
+                            )
+                        else
+                            jsonb_build_object(
+                                'old_record',
+                                (select jsonb_object_agg((c).name, (c).value) from unnest(old_columns) c where (c).is_selectable)
+                            )
+                    end
                 else '{}'::jsonb
             end;
 

--- a/test/expected/test_error_payload_too_large.out
+++ b/test/expected/test_error_payload_too_large.out
@@ -41,6 +41,7 @@ from
      "type": "UPDATE",                         +|                |                                        | 
      "table": "notes",                         +|                |                                        | 
      "record": {                               +|                |                                        | 
+         "id": 1                               +|                |                                        | 
      },                                        +|                |                                        | 
      "schema": "public",                       +|                |                                        | 
      "columns": [                              +|                |                                        | 
@@ -54,6 +55,7 @@ from
          }                                     +|                |                                        | 
      ],                                        +|                |                                        | 
      "old_record": {                           +|                |                                        | 
+         "id": 1                               +|                |                                        | 
      },                                        +|                |                                        | 
      "commit_timestamp": "2000-01-01T00:01:01Z"+|                |                                        | 
  }                                              |                |                                        | 


### PR DESCRIPTION
## What kind of change does this PR introduce?
When payload size causes an error, include data in `record` and `old_record` objects for columns where the value payload is <= 64 bytes

This is expected to provide the user enough context to re-fetch the record if needed

## What is the current behavior?
All value data is omitted when message payload size is too large.

Please link any relevant issues here.
https://github.com/supabase/realtime/issues/252