### PR TITLE
Fix a typo in example of `realtime.build_prepared_statement_sql`

### DIFF
--- a/sql/walrus--0.1.sql
+++ b/sql/walrus--0.1.sql
@@ -214,7 +214,7 @@ Builds a sql string that, if executed, creates a prepared statement to
 tests retrive a row from *entity* by its primary key columns.
 
 Example
-    select realtime.build_prepared_statment_sql('public.notes', '{"id"}'::text[], '{"bigint"}'::text[])
+    select realtime.build_prepared_statement_sql('public.notes', '{"id"}'::text[], '{"bigint"}'::text[])
 */
     select
 'prepare ' || prepared_statement_name || ' as


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs
