### PR TITLE
Handle Null values in filters

### DIFF
--- a/bin/installcheck
+++ b/bin/installcheck
@@ -41,7 +41,7 @@ REGRESS="${PGXS}/../test/regress/pg_regress"
 TESTS=$(ls ${TESTDIR}/sql | sed -e 's/\..*$//' | sort )
 
 # Execute the test fixtures
-psql -v ON_ERROR_STOP=1 -f sql/setup.sql -f sql/walrus--0.1.sql -f sql/walrus_migration_0001*.sql  -f test/fixtures.sql -d contrib_regression
+psql -v ON_ERROR_STOP=1 -f sql/setup.sql -f sql/walrus--0.1.sql -f sql/walrus_migration_0001*.sql -f sql/walrus_migration_0002*.sql -f test/fixtures.sql -d contrib_regression
 
 # Run tests
 ${REGRESS} --use-existing --dbname=contrib_regression --inputdir=${TESTDIR} ${TESTS}

--- a/sql/walrus_migration_0002_filter_handle_nulls.sql
+++ b/sql/walrus_migration_0002_filter_handle_nulls.sql
@@ -1,0 +1,32 @@
+create or replace function realtime.is_visible_through_filters(columns realtime.wal_column[], filters realtime.user_defined_filter[])
+    returns bool
+    language sql
+    immutable
+as $$
+/*
+Should the record be visible (true) or filtered out (false) after *filters* are applied
+*/
+    select
+        -- Default to allowed when no filters present
+        $2 is null -- no filters. this should not happen because subscriptions has a default
+        or array_length($2, 1) is null -- array length of an empty array is null... wtf
+        or bool_and(
+            coalesce(
+                realtime.check_equality_op(
+                    op:=f.op,
+                    type_:=coalesce(
+                        col.type_oid::regtype, -- null when wal2json version <= 2.4
+                        col.type_name::regtype
+                    ),
+                    -- cast jsonb to text
+                    val_1:=col.value #>> '{}',
+                    val_2:=f.value
+                ),
+                false -- if null, filter does not match
+            )
+        )
+    from
+        unnest(filters) f
+        join unnest(columns) col
+            on f.column_name = col.name;
+$$;

--- a/test/expected/issue_55_null_passes_filters.out
+++ b/test/expected/issue_55_null_passes_filters.out
@@ -1,0 +1,133 @@
+select 1 from pg_create_logical_replication_slot('realtime', 'wal2json', false);
+ ?column? 
+----------
+        1
+(1 row)
+
+create table public.notes(
+    id serial primary key,
+    page_id int
+);
+insert into realtime.subscription(subscription_id, entity, claims, filters)
+select
+    seed_uuid(1),
+    'public.notes',
+    jsonb_build_object(
+        'role', 'authenticated',
+        'email', 'example@example.com',
+        'sub', seed_uuid(1)::text
+    ),
+    array[('page_id', 'eq', '5')::realtime.user_defined_filter];
+select clear_wal();
+ clear_wal 
+-----------
+ 
+(1 row)
+
+-- Expect 0 subscriptions: filters do not match: 5 <> 1
+insert into public.notes(page_id) values (1);
+select
+    rec,
+    is_rls_enabled,
+    subscription_ids,
+    errors
+from
+   walrus;
+                      rec                       | is_rls_enabled | subscription_ids | errors 
+------------------------------------------------+----------------+------------------+--------
+ {                                             +| f              | {}               | {}
+     "type": "INSERT",                         +|                |                  | 
+     "table": "notes",                         +|                |                  | 
+     "record": {                               +|                |                  | 
+         "id": 1,                              +|                |                  | 
+         "page_id": 1                          +|                |                  | 
+     },                                        +|                |                  | 
+     "schema": "public",                       +|                |                  | 
+     "columns": [                              +|                |                  | 
+         {                                     +|                |                  | 
+             "name": "id",                     +|                |                  | 
+             "type": "int4"                    +|                |                  | 
+         },                                    +|                |                  | 
+         {                                     +|                |                  | 
+             "name": "page_id",                +|                |                  | 
+             "type": "int4"                    +|                |                  | 
+         }                                     +|                |                  | 
+     ],                                        +|                |                  | 
+     "commit_timestamp": "2000-01-01T00:01:01Z"+|                |                  | 
+ }                                              |                |                  | 
+(1 row)
+
+-- Expect 1 subscription: filters do match 5 = 5
+insert into public.notes(page_id) values (5);
+select
+    rec,
+    is_rls_enabled,
+    subscription_ids,
+    errors
+from
+   walrus;
+                      rec                       | is_rls_enabled |            subscription_ids            | errors 
+------------------------------------------------+----------------+----------------------------------------+--------
+ {                                             +| f              | {f4539ebe-c779-5788-bbc1-2421ffaa8954} | {}
+     "type": "INSERT",                         +|                |                                        | 
+     "table": "notes",                         +|                |                                        | 
+     "record": {                               +|                |                                        | 
+         "id": 2,                              +|                |                                        | 
+         "page_id": 5                          +|                |                                        | 
+     },                                        +|                |                                        | 
+     "schema": "public",                       +|                |                                        | 
+     "columns": [                              +|                |                                        | 
+         {                                     +|                |                                        | 
+             "name": "id",                     +|                |                                        | 
+             "type": "int4"                    +|                |                                        | 
+         },                                    +|                |                                        | 
+         {                                     +|                |                                        | 
+             "name": "page_id",                +|                |                                        | 
+             "type": "int4"                    +|                |                                        | 
+         }                                     +|                |                                        | 
+     ],                                        +|                |                                        | 
+     "commit_timestamp": "2000-01-01T00:01:01Z"+|                |                                        | 
+ }                                              |                |                                        | 
+(1 row)
+
+-- Expect 0 subscriptions: filters do match 5 <> null
+insert into public.notes(page_id) values (null);
+select
+    rec,
+    is_rls_enabled,
+    subscription_ids,
+    errors
+from
+   walrus;
+                      rec                       | is_rls_enabled | subscription_ids | errors 
+------------------------------------------------+----------------+------------------+--------
+ {                                             +| f              | {}               | {}
+     "type": "INSERT",                         +|                |                  | 
+     "table": "notes",                         +|                |                  | 
+     "record": {                               +|                |                  | 
+         "id": 3,                              +|                |                  | 
+         "page_id": null                       +|                |                  | 
+     },                                        +|                |                  | 
+     "schema": "public",                       +|                |                  | 
+     "columns": [                              +|                |                  | 
+         {                                     +|                |                  | 
+             "name": "id",                     +|                |                  | 
+             "type": "int4"                    +|                |                  | 
+         },                                    +|                |                  | 
+         {                                     +|                |                  | 
+             "name": "page_id",                +|                |                  | 
+             "type": "int4"                    +|                |                  | 
+         }                                     +|                |                  | 
+     ],                                        +|                |                  | 
+     "commit_timestamp": "2000-01-01T00:01:01Z"+|                |                  | 
+ }                                              |                |                  | 
+(1 row)
+
+drop table public.notes;
+select pg_drop_replication_slot('realtime');
+ pg_drop_replication_slot 
+--------------------------
+ 
+(1 row)
+
+truncate table realtime.subscription;

--- a/test/expected/test_unit_filters.out
+++ b/test/expected/test_unit_filters.out
@@ -106,6 +106,12 @@ select realtime.check_equality_op('eq', 'bigint', '2', '1');
  f
 (1 row)
 
+select realtime.check_equality_op('eq', 'bigint', '2', null);
+ check_equality_op 
+-------------------
+ 
+(1 row)
+
 select realtime.check_equality_op('eq','uuid','639f86b1-738b-43ed-bb09-c8d3f3bafa30','639f86b1-738b-43ed-bb09-c8d3f3bafa30');
  check_equality_op 
 -------------------

--- a/test/sql/issue_55_null_passes_filters.sql
+++ b/test/sql/issue_55_null_passes_filters.sql
@@ -1,0 +1,60 @@
+select 1 from pg_create_logical_replication_slot('realtime', 'wal2json', false);
+
+create table public.notes(
+    id serial primary key,
+    page_id int
+);
+
+insert into realtime.subscription(subscription_id, entity, claims, filters)
+select
+    seed_uuid(1),
+    'public.notes',
+    jsonb_build_object(
+        'role', 'authenticated',
+        'email', 'example@example.com',
+        'sub', seed_uuid(1)::text
+    ),
+    array[('page_id', 'eq', '5')::realtime.user_defined_filter];
+
+select clear_wal();
+
+
+-- Expect 0 subscriptions: filters do not match: 5 <> 1
+insert into public.notes(page_id) values (1);
+select
+    rec,
+    is_rls_enabled,
+    subscription_ids,
+    errors
+from
+   walrus;
+
+
+
+-- Expect 1 subscription: filters do match 5 = 5
+insert into public.notes(page_id) values (5);
+select
+    rec,
+    is_rls_enabled,
+    subscription_ids,
+    errors
+from
+   walrus;
+
+
+
+-- Expect 0 subscriptions: filters do match 5 <> null
+insert into public.notes(page_id) values (null);
+select
+    rec,
+    is_rls_enabled,
+    subscription_ids,
+    errors
+from
+   walrus;
+
+
+
+drop table public.notes;
+select pg_drop_replication_slot('realtime');
+truncate table realtime.subscription;

--- a/test/sql/test_unit_filters.sql
+++ b/test/sql/test_unit_filters.sql
@@ -16,6 +16,7 @@ select realtime.check_equality_op('gte', 'text', 'bbb', 'aaa');
 select realtime.check_equality_op('gte', 'text', 'bbb', 'bbb');
 select realtime.check_equality_op('eq', 'bigint', '1', '1');
 select realtime.check_equality_op('eq', 'bigint', '2', '1');
+select realtime.check_equality_op('eq', 'bigint', '2', null);
 
 select realtime.check_equality_op('eq','uuid','639f86b1-738b-43ed-bb09-c8d3f3bafa30','639f86b1-738b-43ed-bb09-c8d3f3bafa30');
 select realtime.check_equality_op('eq','uuid','639f86b1-738b-43ed-bb09-c8d3f3bafa30','b423f213-ac24-402a-95ea-cf1d94d8e9f0');


### PR DESCRIPTION
## What kind of change does this PR introduce?
Currently, when a null value is encountered in a filter, it appears as though the filters match.

This PR updates the filter logic to
- pass if filters are null
- pass if filters are an empty array
- fail if comparison results in a null e.g. `1 = null -> null`

Bug fix, feature, docs update, ...
resolves #55