### PR TITLE
Add milliseconds to commit_timestamp

### DIFF
--- a/bin/installcheck
+++ b/bin/installcheck
@@ -41,7 +41,7 @@ REGRESS="${PGXS}/../test/regress/pg_regress"
 TESTS=$(ls ${TESTDIR}/sql | sed -e 's/\..*$//' | sort )
 
 # Execute the test fixtures
-psql -v ON_ERROR_STOP=1 -f sql/setup.sql -f sql/walrus--0.1.sql -f sql/walrus_migration_0001*.sql -f sql/walrus_migration_0002*.sql -f sql/walrus_migration_0003*.sql -f sql/walrus_migration_0004*.sql -f sql/walrus_migration_0005*.sql -f test/fixtures.sql -d contrib_regression
+psql -v ON_ERROR_STOP=1 -f sql/setup.sql -f sql/walrus--0.1.sql -f sql/walrus_migration_0001*.sql -f sql/walrus_migration_0002*.sql -f sql/walrus_migration_0003*.sql -f sql/walrus_migration_0004*.sql -f sql/walrus_migration_0005*.sql -f sql/walrus_migration_0006*.sql -f test/fixtures.sql -d contrib_regression
 
 # Run tests
 ${REGRESS} --use-existing --dbname=contrib_regression --inputdir=${TESTDIR} ${TESTS}

--- a/sql/walrus_migration_0006_high_res_commit_timestamp.sql
+++ b/sql/walrus_migration_0006_high_res_commit_timestamp.sql
@@ -1,0 +1,285 @@
+create or replace function realtime.apply_rls(wal jsonb, max_record_bytes int = 1024 * 1024)
+    returns setof realtime.wal_rls
+    language plpgsql
+    volatile
+as $$
+declare
+    -- Regclass of the table e.g. public.notes
+    entity_ regclass = (quote_ident(wal ->> 'schema') || '.' || quote_ident(wal ->> 'table'))::regclass;
+
+    -- I, U, D, T: insert, update ...
+    action realtime.action = (
+        case wal ->> 'action'
+            when 'I' then 'INSERT'
+            when 'U' then 'UPDATE'
+            when 'D' then 'DELETE'
+            else 'ERROR'
+        end
+    );
+
+    -- Is row level security enabled for the table
+    is_rls_enabled bool = relrowsecurity from pg_class where oid = entity_;
+
+    subscriptions realtime.subscription[] = array_agg(subs)
+        from
+            realtime.subscription subs
+        where
+            subs.entity = entity_;
+
+    -- Subscription vars
+    roles regrole[] = array_agg(distinct us.claims_role)
+        from
+            unnest(subscriptions) us;
+
+    working_role regrole;
+    claimed_role regrole;
+    claims jsonb;
+
+    subscription_id uuid;
+    subscription_has_access bool;
+    visible_to_subscription_ids uuid[] = '{}';
+
+    -- structured info for wal's columns
+    columns realtime.wal_column[];
+    -- previous identity values for update/delete
+    old_columns realtime.wal_column[];
+
+    error_record_exceeds_max_size boolean = octet_length(wal::text) > max_record_bytes;
+
+    -- Primary jsonb output for record
+    output jsonb;
+
+begin
+    perform set_config('role', null, true);
+
+    columns =
+        array_agg(
+            (
+                x->>'name',
+                x->>'type',
+                x->>'typeoid',
+                realtime.cast(
+                    (x->'value') #>> '{}',
+                    coalesce(
+                        (x->>'typeoid')::regtype, -- null when wal2json version <= 2.4
+                        (x->>'type')::regtype
+                    )
+                ),
+                (pks ->> 'name') is not null,
+                true
+            )::realtime.wal_column
+        )
+        from
+            jsonb_array_elements(wal -> 'columns') x
+            left join jsonb_array_elements(wal -> 'pk') pks
+                on (x ->> 'name') = (pks ->> 'name');
+
+    old_columns =
+        array_agg(
+            (
+                x->>'name',
+                x->>'type',
+                x->>'typeoid',
+                realtime.cast(
+                    (x->'value') #>> '{}',
+                    coalesce(
+                        (x->>'typeoid')::regtype, -- null when wal2json version <= 2.4
+                        (x->>'type')::regtype
+                    )
+                ),
+                (pks ->> 'name') is not null,
+                true
+            )::realtime.wal_column
+        )
+        from
+            jsonb_array_elements(wal -> 'identity') x
+            left join jsonb_array_elements(wal -> 'pk') pks
+                on (x ->> 'name') = (pks ->> 'name');
+
+    for working_role in select * from unnest(roles) loop
+
+        -- Update `is_selectable` for columns and old_columns
+        columns =
+            array_agg(
+                (
+                    c.name,
+                    c.type_name,
+                    c.type_oid,
+                    c.value,
+                    c.is_pkey,
+                    pg_catalog.has_column_privilege(working_role, entity_, c.name, 'SELECT')
+                )::realtime.wal_column
+            )
+            from
+                unnest(columns) c;
+
+        old_columns =
+                array_agg(
+                    (
+                        c.name,
+                        c.type_name,
+                        c.type_oid,
+                        c.value,
+                        c.is_pkey,
+                        pg_catalog.has_column_privilege(working_role, entity_, c.name, 'SELECT')
+                    )::realtime.wal_column
+                )
+                from
+                    unnest(old_columns) c;
+
+        if action <> 'DELETE' and count(1) = 0 from unnest(columns) c where c.is_pkey then
+            return next (
+                jsonb_build_object(
+                    'schema', wal ->> 'schema',
+                    'table', wal ->> 'table',
+                    'type', action
+                ),
+                is_rls_enabled,
+                -- subscriptions is already filtered by entity
+                (select array_agg(s.subscription_id) from unnest(subscriptions) as s where claims_role = working_role),
+                array['Error 400: Bad Request, no primary key']
+            )::realtime.wal_rls;
+
+        -- The claims role does not have SELECT permission to the primary key of entity
+        elsif action <> 'DELETE' and sum(c.is_selectable::int) <> count(1) from unnest(columns) c where c.is_pkey then
+            return next (
+                jsonb_build_object(
+                    'schema', wal ->> 'schema',
+                    'table', wal ->> 'table',
+                    'type', action
+                ),
+                is_rls_enabled,
+                (select array_agg(s.subscription_id) from unnest(subscriptions) as s where claims_role = working_role),
+                array['Error 401: Unauthorized']
+            )::realtime.wal_rls;
+
+        else
+            output = jsonb_build_object(
+                'schema', wal ->> 'schema',
+                'table', wal ->> 'table',
+                'type', action,
+                'commit_timestamp', to_char(
+                    (wal ->> 'timestamp')::timestamptz,
+                    'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'
+                ),
+                'columns', (
+                    select
+                        jsonb_agg(
+                            jsonb_build_object(
+                                'name', pa.attname,
+                                'type', pt.typname
+                            )
+                            order by pa.attnum asc
+                        )
+                    from
+                        pg_attribute pa
+                        join pg_type pt
+                            on pa.atttypid = pt.oid
+                    where
+                        attrelid = entity_
+                        and attnum > 0
+                        and pg_catalog.has_column_privilege(working_role, entity_, pa.attname, 'SELECT')
+                )
+            )
+            -- Add "record" key for insert and update
+            || case
+                when action in ('INSERT', 'UPDATE') then
+                    jsonb_build_object(
+                        'record',
+                        (
+                            select jsonb_object_agg((c).name, (c).value)
+                            from unnest(columns) c
+                            where
+                                (c).is_selectable
+                                and ( not error_record_exceeds_max_size or (octet_length((c).value::text) <= 64))
+                        )
+                    )
+                else '{}'::jsonb
+            end
+            -- Add "old_record" key for update and delete
+            || case
+                when action = 'UPDATE' then
+                    jsonb_build_object(
+                            'old_record',
+                            (
+                                select jsonb_object_agg((c).name, (c).value)
+                                from unnest(old_columns) c
+                                where
+                                    (c).is_selectable
+                                    and ( not error_record_exceeds_max_size or (octet_length((c).value::text) <= 64))
+                            )
+                        )
+                when action = 'DELETE' then
+                    jsonb_build_object(
+                        'old_record',
+                        (
+                            select jsonb_object_agg((c).name, (c).value)
+                            from unnest(old_columns) c
+                            where
+                                (c).is_selectable
+                                and ( not error_record_exceeds_max_size or (octet_length((c).value::text) <= 64))
+                                and ( not is_rls_enabled or (c).is_pkey ) -- if RLS enabled, we can't secure deletes so filter to pkey
+                        )
+                    )
+                else '{}'::jsonb
+            end;
+
+            -- Create the prepared statement
+            if is_rls_enabled and action <> 'DELETE' then
+                if (select 1 from pg_prepared_statements where name = 'walrus_rls_stmt' limit 1) > 0 then
+                    deallocate walrus_rls_stmt;
+                end if;
+                execute realtime.build_prepared_statement_sql('walrus_rls_stmt', entity_, columns);
+            end if;
+
+            visible_to_subscription_ids = '{}';
+
+            for subscription_id, claims in (
+                    select
+                        subs.subscription_id,
+                        subs.claims
+                    from
+                        unnest(subscriptions) subs
+                    where
+                        subs.entity = entity_
+                        and subs.claims_role = working_role
+                        and (
+                            realtime.is_visible_through_filters(columns, subs.filters)
+                            or action = 'DELETE'
+                        )
+            ) loop
+
+                if not is_rls_enabled or action = 'DELETE' then
+                    visible_to_subscription_ids = visible_to_subscription_ids || subscription_id;
+                else
+                    -- Check if RLS allows the role to see the record
+                    perform
+                        set_config('role', working_role::text, true),
+                        set_config('request.jwt.claims', claims::text, true);
+
+                    execute 'execute walrus_rls_stmt' into subscription_has_access;
+
+                    if subscription_has_access then
+                        visible_to_subscription_ids = visible_to_subscription_ids || subscription_id;
+                    end if;
+                end if;
+            end loop;
+
+            perform set_config('role', null, true);
+
+            return next (
+                output,
+                is_rls_enabled,
+                visible_to_subscription_ids,
+                case
+                    when error_record_exceeds_max_size then array['Error 413: Payload Too Large']
+                    else '{}'
+                end
+            )::realtime.wal_rls;
+
+        end if;
+    end loop;
+
+    perform set_config('role', null, true);
+end;
+$$;

--- a/test/expected/issue_40_quoted_regtype.out
+++ b/test/expected/issue_40_quoted_regtype.out
@@ -37,48 +37,48 @@ select
     errors
 from
    walrus;
-                      rec                       | is_rls_enabled |            subscription_ids            | errors 
-------------------------------------------------+----------------+----------------------------------------+--------
- {                                             +| t              | {f4539ebe-c779-5788-bbc1-2421ffaa8954} | {}
-     "type": "INSERT",                         +|                |                                        | 
-     "table": "notes",                         +|                |                                        | 
-     "record": {                               +|                |                                        | 
-         "id": 1,                              +|                |                                        | 
-         "primary_color": "RED"                +|                |                                        | 
-     },                                        +|                |                                        | 
-     "schema": "public",                       +|                |                                        | 
-     "columns": [                              +|                |                                        | 
-         {                                     +|                |                                        | 
-             "name": "id",                     +|                |                                        | 
-             "type": "int4"                    +|                |                                        | 
-         },                                    +|                |                                        | 
-         {                                     +|                |                                        | 
-             "name": "primary_color",          +|                |                                        | 
-             "type": "Color"                   +|                |                                        | 
-         }                                     +|                |                                        | 
-     ],                                        +|                |                                        | 
-     "commit_timestamp": "2000-01-01T00:01:01Z"+|                |                                        | 
- }                                              |                |                                        | 
- {                                             +| t              | {}                                     | {}
-     "type": "INSERT",                         +|                |                                        | 
-     "table": "notes",                         +|                |                                        | 
-     "record": {                               +|                |                                        | 
-         "id": 2,                              +|                |                                        | 
-         "primary_color": "GREEN"              +|                |                                        | 
-     },                                        +|                |                                        | 
-     "schema": "public",                       +|                |                                        | 
-     "columns": [                              +|                |                                        | 
-         {                                     +|                |                                        | 
-             "name": "id",                     +|                |                                        | 
-             "type": "int4"                    +|                |                                        | 
-         },                                    +|                |                                        | 
-         {                                     +|                |                                        | 
-             "name": "primary_color",          +|                |                                        | 
-             "type": "Color"                   +|                |                                        | 
-         }                                     +|                |                                        | 
-     ],                                        +|                |                                        | 
-     "commit_timestamp": "2000-01-01T00:01:01Z"+|                |                                        | 
- }                                              |                |                                        | 
+                        rec                         | is_rls_enabled |            subscription_ids            | errors 
+----------------------------------------------------+----------------+----------------------------------------+--------
+ {                                                 +| t              | {f4539ebe-c779-5788-bbc1-2421ffaa8954} | {}
+     "type": "INSERT",                             +|                |                                        | 
+     "table": "notes",                             +|                |                                        | 
+     "record": {                                   +|                |                                        | 
+         "id": 1,                                  +|                |                                        | 
+         "primary_color": "RED"                    +|                |                                        | 
+     },                                            +|                |                                        | 
+     "schema": "public",                           +|                |                                        | 
+     "columns": [                                  +|                |                                        | 
+         {                                         +|                |                                        | 
+             "name": "id",                         +|                |                                        | 
+             "type": "int4"                        +|                |                                        | 
+         },                                        +|                |                                        | 
+         {                                         +|                |                                        | 
+             "name": "primary_color",              +|                |                                        | 
+             "type": "Color"                       +|                |                                        | 
+         }                                         +|                |                                        | 
+     ],                                            +|                |                                        | 
+     "commit_timestamp": "2000-01-01T00:01:01.000Z"+|                |                                        | 
+ }                                                  |                |                                        | 
+ {                                                 +| t              | {}                                     | {}
+     "type": "INSERT",                             +|                |                                        | 
+     "table": "notes",                             +|                |                                        | 
+     "record": {                                   +|                |                                        | 
+         "id": 2,                                  +|                |                                        | 
+         "primary_color": "GREEN"                  +|                |                                        | 
+     },                                            +|                |                                        | 
+     "schema": "public",                           +|                |                                        | 
+     "columns": [                                  +|                |                                        | 
+         {                                         +|                |                                        | 
+             "name": "id",                         +|                |                                        | 
+             "type": "int4"                        +|                |                                        | 
+         },                                        +|                |                                        | 
+         {                                         +|                |                                        | 
+             "name": "primary_color",              +|                |                                        | 
+             "type": "Color"                       +|                |                                        | 
+         }                                         +|                |                                        | 
+     ],                                            +|                |                                        | 
+     "commit_timestamp": "2000-01-01T00:01:01.000Z"+|                |                                        | 
+ }                                                  |                |                                        | 
 (2 rows)
 
 drop table public.notes;

--- a/test/expected/issue_55_null_passes_filters.out
+++ b/test/expected/issue_55_null_passes_filters.out
@@ -33,28 +33,28 @@ select
     errors
 from
    walrus;
-                      rec                       | is_rls_enabled | subscription_ids | errors 
-------------------------------------------------+----------------+------------------+--------
- {                                             +| f              | {}               | {}
-     "type": "INSERT",                         +|                |                  | 
-     "table": "notes",                         +|                |                  | 
-     "record": {                               +|                |                  | 
-         "id": 1,                              +|                |                  | 
-         "page_id": 1                          +|                |                  | 
-     },                                        +|                |                  | 
-     "schema": "public",                       +|                |                  | 
-     "columns": [                              +|                |                  | 
-         {                                     +|                |                  | 
-             "name": "id",                     +|                |                  | 
-             "type": "int4"                    +|                |                  | 
-         },                                    +|                |                  | 
-         {                                     +|                |                  | 
-             "name": "page_id",                +|                |                  | 
-             "type": "int4"                    +|                |                  | 
-         }                                     +|                |                  | 
-     ],                                        +|                |                  | 
-     "commit_timestamp": "2000-01-01T00:01:01Z"+|                |                  | 
- }                                              |                |                  | 
+                        rec                         | is_rls_enabled | subscription_ids | errors 
+----------------------------------------------------+----------------+------------------+--------
+ {                                                 +| f              | {}               | {}
+     "type": "INSERT",                             +|                |                  | 
+     "table": "notes",                             +|                |                  | 
+     "record": {                                   +|                |                  | 
+         "id": 1,                                  +|                |                  | 
+         "page_id": 1                              +|                |                  | 
+     },                                            +|                |                  | 
+     "schema": "public",                           +|                |                  | 
+     "columns": [                                  +|                |                  | 
+         {                                         +|                |                  | 
+             "name": "id",                         +|                |                  | 
+             "type": "int4"                        +|                |                  | 
+         },                                        +|                |                  | 
+         {                                         +|                |                  | 
+             "name": "page_id",                    +|                |                  | 
+             "type": "int4"                        +|                |                  | 
+         }                                         +|                |                  | 
+     ],                                            +|                |                  | 
+     "commit_timestamp": "2000-01-01T00:01:01.000Z"+|                |                  | 
+ }                                                  |                |                  | 
 (1 row)
 
 -- Expect 1 subscription: filters do match 5 = 5
@@ -66,28 +66,28 @@ select
     errors
 from
    walrus;
-                      rec                       | is_rls_enabled |            subscription_ids            | errors 
-------------------------------------------------+----------------+----------------------------------------+--------
- {                                             +| f              | {f4539ebe-c779-5788-bbc1-2421ffaa8954} | {}
-     "type": "INSERT",                         +|                |                                        | 
-     "table": "notes",                         +|                |                                        | 
-     "record": {                               +|                |                                        | 
-         "id": 2,                              +|                |                                        | 
-         "page_id": 5                          +|                |                                        | 
-     },                                        +|                |                                        | 
-     "schema": "public",                       +|                |                                        | 
-     "columns": [                              +|                |                                        | 
-         {                                     +|                |                                        | 
-             "name": "id",                     +|                |                                        | 
-             "type": "int4"                    +|                |                                        | 
-         },                                    +|                |                                        | 
-         {                                     +|                |                                        | 
-             "name": "page_id",                +|                |                                        | 
-             "type": "int4"                    +|                |                                        | 
-         }                                     +|                |                                        | 
-     ],                                        +|                |                                        | 
-     "commit_timestamp": "2000-01-01T00:01:01Z"+|                |                                        | 
- }                                              |                |                                        | 
+                        rec                         | is_rls_enabled |            subscription_ids            | errors 
+----------------------------------------------------+----------------+----------------------------------------+--------
+ {                                                 +| f              | {f4539ebe-c779-5788-bbc1-2421ffaa8954} | {}
+     "type": "INSERT",                             +|                |                                        | 
+     "table": "notes",                             +|                |                                        | 
+     "record": {                                   +|                |                                        | 
+         "id": 2,                                  +|                |                                        | 
+         "page_id": 5                              +|                |                                        | 
+     },                                            +|                |                                        | 
+     "schema": "public",                           +|                |                                        | 
+     "columns": [                                  +|                |                                        | 
+         {                                         +|                |                                        | 
+             "name": "id",                         +|                |                                        | 
+             "type": "int4"                        +|                |                                        | 
+         },                                        +|                |                                        | 
+         {                                         +|                |                                        | 
+             "name": "page_id",                    +|                |                                        | 
+             "type": "int4"                        +|                |                                        | 
+         }                                         +|                |                                        | 
+     ],                                            +|                |                                        | 
+     "commit_timestamp": "2000-01-01T00:01:01.000Z"+|                |                                        | 
+ }                                                  |                |                                        | 
 (1 row)
 
 -- Expect 0 subscriptions: filters do match 5 <> null
@@ -99,28 +99,28 @@ select
     errors
 from
    walrus;
-                      rec                       | is_rls_enabled | subscription_ids | errors 
-------------------------------------------------+----------------+------------------+--------
- {                                             +| f              | {}               | {}
-     "type": "INSERT",                         +|                |                  | 
-     "table": "notes",                         +|                |                  | 
-     "record": {                               +|                |                  | 
-         "id": 3,                              +|                |                  | 
-         "page_id": null                       +|                |                  | 
-     },                                        +|                |                  | 
-     "schema": "public",                       +|                |                  | 
-     "columns": [                              +|                |                  | 
-         {                                     +|                |                  | 
-             "name": "id",                     +|                |                  | 
-             "type": "int4"                    +|                |                  | 
-         },                                    +|                |                  | 
-         {                                     +|                |                  | 
-             "name": "page_id",                +|                |                  | 
-             "type": "int4"                    +|                |                  | 
-         }                                     +|                |                  | 
-     ],                                        +|                |                  | 
-     "commit_timestamp": "2000-01-01T00:01:01Z"+|                |                  | 
- }                                              |                |                  | 
+                        rec                         | is_rls_enabled | subscription_ids | errors 
+----------------------------------------------------+----------------+------------------+--------
+ {                                                 +| f              | {}               | {}
+     "type": "INSERT",                             +|                |                  | 
+     "table": "notes",                             +|                |                  | 
+     "record": {                                   +|                |                  | 
+         "id": 3,                                  +|                |                  | 
+         "page_id": null                           +|                |                  | 
+     },                                            +|                |                  | 
+     "schema": "public",                           +|                |                  | 
+     "columns": [                                  +|                |                  | 
+         {                                         +|                |                  | 
+             "name": "id",                         +|                |                  | 
+             "type": "int4"                        +|                |                  | 
+         },                                        +|                |                  | 
+         {                                         +|                |                  | 
+             "name": "page_id",                    +|                |                  | 
+             "type": "int4"                        +|                |                  | 
+         }                                         +|                |                  | 
+     ],                                            +|                |                  | 
+     "commit_timestamp": "2000-01-01T00:01:01.000Z"+|                |                  | 
+ }                                                  |                |                  | 
 (1 row)
 
 drop table public.notes;

--- a/test/expected/test_column_permissions_hide_columns.out
+++ b/test/expected/test_column_permissions_hide_columns.out
@@ -32,23 +32,23 @@ select
     errors
 from
    walrus;
-                      rec                       | is_rls_enabled |            subscription_ids            | errors 
-------------------------------------------------+----------------+----------------------------------------+--------
- {                                             +| f              | {f4539ebe-c779-5788-bbc1-2421ffaa8954} | {}
-     "type": "INSERT",                         +|                |                                        | 
-     "table": "notes",                         +|                |                                        | 
-     "record": {                               +|                |                                        | 
-         "id": 1                               +|                |                                        | 
-     },                                        +|                |                                        | 
-     "schema": "public",                       +|                |                                        | 
-     "columns": [                              +|                |                                        | 
-         {                                     +|                |                                        | 
-             "name": "id",                     +|                |                                        | 
-             "type": "int4"                    +|                |                                        | 
-         }                                     +|                |                                        | 
-     ],                                        +|                |                                        | 
-     "commit_timestamp": "2000-01-01T00:01:01Z"+|                |                                        | 
- }                                              |                |                                        | 
+                        rec                         | is_rls_enabled |            subscription_ids            | errors 
+----------------------------------------------------+----------------+----------------------------------------+--------
+ {                                                 +| f              | {f4539ebe-c779-5788-bbc1-2421ffaa8954} | {}
+     "type": "INSERT",                             +|                |                                        | 
+     "table": "notes",                             +|                |                                        | 
+     "record": {                                   +|                |                                        | 
+         "id": 1                                   +|                |                                        | 
+     },                                            +|                |                                        | 
+     "schema": "public",                           +|                |                                        | 
+     "columns": [                                  +|                |                                        | 
+         {                                         +|                |                                        | 
+             "name": "id",                         +|                |                                        | 
+             "type": "int4"                        +|                |                                        | 
+         }                                         +|                |                                        | 
+     ],                                            +|                |                                        | 
+     "commit_timestamp": "2000-01-01T00:01:01.000Z"+|                |                                        | 
+ }                                                  |                |                                        | 
 (1 row)
 
 drop table public.notes;

--- a/test/expected/test_delete_old_record_behavior.out
+++ b/test/expected/test_delete_old_record_behavior.out
@@ -42,27 +42,27 @@ select
     errors
 from
    walrus;
-                      rec                       | is_rls_enabled |            subscription_ids            | errors 
-------------------------------------------------+----------------+----------------------------------------+--------
- {                                             +| f              | {f4539ebe-c779-5788-bbc1-2421ffaa8954} | {}
-     "type": "DELETE",                         +|                |                                        | 
-     "table": "notes",                         +|                |                                        | 
-     "schema": "public",                       +|                |                                        | 
-     "columns": [                              +|                |                                        | 
-         {                                     +|                |                                        | 
-             "name": "pk1",                    +|                |                                        | 
-             "type": "int4"                    +|                |                                        | 
-         },                                    +|                |                                        | 
-         {                                     +|                |                                        | 
-             "name": "body",                   +|                |                                        | 
-             "type": "text"                    +|                |                                        | 
-         }                                     +|                |                                        | 
-     ],                                        +|                |                                        | 
-     "old_record": {                           +|                |                                        | 
-         "pk1": 1                              +|                |                                        | 
-     },                                        +|                |                                        | 
-     "commit_timestamp": "2000-01-01T00:01:01Z"+|                |                                        | 
- }                                              |                |                                        | 
+                        rec                         | is_rls_enabled |            subscription_ids            | errors 
+----------------------------------------------------+----------------+----------------------------------------+--------
+ {                                                 +| f              | {f4539ebe-c779-5788-bbc1-2421ffaa8954} | {}
+     "type": "DELETE",                             +|                |                                        | 
+     "table": "notes",                             +|                |                                        | 
+     "schema": "public",                           +|                |                                        | 
+     "columns": [                                  +|                |                                        | 
+         {                                         +|                |                                        | 
+             "name": "pk1",                        +|                |                                        | 
+             "type": "int4"                        +|                |                                        | 
+         },                                        +|                |                                        | 
+         {                                         +|                |                                        | 
+             "name": "body",                       +|                |                                        | 
+             "type": "text"                        +|                |                                        | 
+         }                                         +|                |                                        | 
+     ],                                            +|                |                                        | 
+     "old_record": {                               +|                |                                        | 
+         "pk1": 1                                  +|                |                                        | 
+     },                                            +|                |                                        | 
+     "commit_timestamp": "2000-01-01T00:01:01.000Z"+|                |                                        | 
+ }                                                  |                |                                        | 
 (1 row)
 
 -- Option 2:
@@ -87,27 +87,27 @@ select
     errors
 from
    walrus;
-                      rec                       | is_rls_enabled |            subscription_ids            | errors 
-------------------------------------------------+----------------+----------------------------------------+--------
- {                                             +| t              | {f4539ebe-c779-5788-bbc1-2421ffaa8954} | {}
-     "type": "DELETE",                         +|                |                                        | 
-     "table": "notes",                         +|                |                                        | 
-     "schema": "public",                       +|                |                                        | 
-     "columns": [                              +|                |                                        | 
-         {                                     +|                |                                        | 
-             "name": "pk1",                    +|                |                                        | 
-             "type": "int4"                    +|                |                                        | 
-         },                                    +|                |                                        | 
-         {                                     +|                |                                        | 
-             "name": "body",                   +|                |                                        | 
-             "type": "text"                    +|                |                                        | 
-         }                                     +|                |                                        | 
-     ],                                        +|                |                                        | 
-     "old_record": {                           +|                |                                        | 
-         "pk1": 1                              +|                |                                        | 
-     },                                        +|                |                                        | 
-     "commit_timestamp": "2000-01-01T00:01:01Z"+|                |                                        | 
- }                                              |                |                                        | 
+                        rec                         | is_rls_enabled |            subscription_ids            | errors 
+----------------------------------------------------+----------------+----------------------------------------+--------
+ {                                                 +| t              | {f4539ebe-c779-5788-bbc1-2421ffaa8954} | {}
+     "type": "DELETE",                             +|                |                                        | 
+     "table": "notes",                             +|                |                                        | 
+     "schema": "public",                           +|                |                                        | 
+     "columns": [                                  +|                |                                        | 
+         {                                         +|                |                                        | 
+             "name": "pk1",                        +|                |                                        | 
+             "type": "int4"                        +|                |                                        | 
+         },                                        +|                |                                        | 
+         {                                         +|                |                                        | 
+             "name": "body",                       +|                |                                        | 
+             "type": "text"                        +|                |                                        | 
+         }                                         +|                |                                        | 
+     ],                                            +|                |                                        | 
+     "old_record": {                               +|                |                                        | 
+         "pk1": 1                                  +|                |                                        | 
+     },                                            +|                |                                        | 
+     "commit_timestamp": "2000-01-01T00:01:01.000Z"+|                |                                        | 
+ }                                                  |                |                                        | 
 (1 row)
 
 -- Option 3:
@@ -132,28 +132,28 @@ select
     errors
 from
    walrus;
-                      rec                       | is_rls_enabled |            subscription_ids            | errors 
-------------------------------------------------+----------------+----------------------------------------+--------
- {                                             +| f              | {f4539ebe-c779-5788-bbc1-2421ffaa8954} | {}
-     "type": "DELETE",                         +|                |                                        | 
-     "table": "notes",                         +|                |                                        | 
-     "schema": "public",                       +|                |                                        | 
-     "columns": [                              +|                |                                        | 
-         {                                     +|                |                                        | 
-             "name": "pk1",                    +|                |                                        | 
-             "type": "int4"                    +|                |                                        | 
-         },                                    +|                |                                        | 
-         {                                     +|                |                                        | 
-             "name": "body",                   +|                |                                        | 
-             "type": "text"                    +|                |                                        | 
-         }                                     +|                |                                        | 
-     ],                                        +|                |                                        | 
-     "old_record": {                           +|                |                                        | 
-         "pk1": 1,                             +|                |                                        | 
-         "body": "take out trash"              +|                |                                        | 
-     },                                        +|                |                                        | 
-     "commit_timestamp": "2000-01-01T00:01:01Z"+|                |                                        | 
- }                                              |                |                                        | 
+                        rec                         | is_rls_enabled |            subscription_ids            | errors 
+----------------------------------------------------+----------------+----------------------------------------+--------
+ {                                                 +| f              | {f4539ebe-c779-5788-bbc1-2421ffaa8954} | {}
+     "type": "DELETE",                             +|                |                                        | 
+     "table": "notes",                             +|                |                                        | 
+     "schema": "public",                           +|                |                                        | 
+     "columns": [                                  +|                |                                        | 
+         {                                         +|                |                                        | 
+             "name": "pk1",                        +|                |                                        | 
+             "type": "int4"                        +|                |                                        | 
+         },                                        +|                |                                        | 
+         {                                         +|                |                                        | 
+             "name": "body",                       +|                |                                        | 
+             "type": "text"                        +|                |                                        | 
+         }                                         +|                |                                        | 
+     ],                                            +|                |                                        | 
+     "old_record": {                               +|                |                                        | 
+         "pk1": 1,                                 +|                |                                        | 
+         "body": "take out trash"                  +|                |                                        | 
+     },                                            +|                |                                        | 
+     "commit_timestamp": "2000-01-01T00:01:01.000Z"+|                |                                        | 
+ }                                                  |                |                                        | 
 (1 row)
 
 -- Option 4:
@@ -178,27 +178,27 @@ select
     errors
 from
    walrus;
-                      rec                       | is_rls_enabled |            subscription_ids            | errors 
-------------------------------------------------+----------------+----------------------------------------+--------
- {                                             +| t              | {f4539ebe-c779-5788-bbc1-2421ffaa8954} | {}
-     "type": "DELETE",                         +|                |                                        | 
-     "table": "notes",                         +|                |                                        | 
-     "schema": "public",                       +|                |                                        | 
-     "columns": [                              +|                |                                        | 
-         {                                     +|                |                                        | 
-             "name": "pk1",                    +|                |                                        | 
-             "type": "int4"                    +|                |                                        | 
-         },                                    +|                |                                        | 
-         {                                     +|                |                                        | 
-             "name": "body",                   +|                |                                        | 
-             "type": "text"                    +|                |                                        | 
-         }                                     +|                |                                        | 
-     ],                                        +|                |                                        | 
-     "old_record": {                           +|                |                                        | 
-         "pk1": 1                              +|                |                                        | 
-     },                                        +|                |                                        | 
-     "commit_timestamp": "2000-01-01T00:01:01Z"+|                |                                        | 
- }                                              |                |                                        | 
+                        rec                         | is_rls_enabled |            subscription_ids            | errors 
+----------------------------------------------------+----------------+----------------------------------------+--------
+ {                                                 +| t              | {f4539ebe-c779-5788-bbc1-2421ffaa8954} | {}
+     "type": "DELETE",                             +|                |                                        | 
+     "table": "notes",                             +|                |                                        | 
+     "schema": "public",                           +|                |                                        | 
+     "columns": [                                  +|                |                                        | 
+         {                                         +|                |                                        | 
+             "name": "pk1",                        +|                |                                        | 
+             "type": "int4"                        +|                |                                        | 
+         },                                        +|                |                                        | 
+         {                                         +|                |                                        | 
+             "name": "body",                       +|                |                                        | 
+             "type": "text"                        +|                |                                        | 
+         }                                         +|                |                                        | 
+     ],                                            +|                |                                        | 
+     "old_record": {                               +|                |                                        | 
+         "pk1": 1                                  +|                |                                        | 
+     },                                            +|                |                                        | 
+     "commit_timestamp": "2000-01-01T00:01:01.000Z"+|                |                                        | 
+ }                                                  |                |                                        | 
 (1 row)
 
 select pg_drop_replication_slot('realtime');

--- a/test/expected/test_error_payload_too_large.out
+++ b/test/expected/test_error_payload_too_large.out
@@ -35,30 +35,30 @@ select
     errors
 from
    walrus;
-                      rec                       | is_rls_enabled |            subscription_ids            |              errors              
-------------------------------------------------+----------------+----------------------------------------+----------------------------------
- {                                             +| f              | {f4539ebe-c779-5788-bbc1-2421ffaa8954} | {"Error 413: Payload Too Large"}
-     "type": "UPDATE",                         +|                |                                        | 
-     "table": "notes",                         +|                |                                        | 
-     "record": {                               +|                |                                        | 
-         "id": 1                               +|                |                                        | 
-     },                                        +|                |                                        | 
-     "schema": "public",                       +|                |                                        | 
-     "columns": [                              +|                |                                        | 
-         {                                     +|                |                                        | 
-             "name": "id",                     +|                |                                        | 
-             "type": "int4"                    +|                |                                        | 
-         },                                    +|                |                                        | 
-         {                                     +|                |                                        | 
-             "name": "body",                   +|                |                                        | 
-             "type": "text"                    +|                |                                        | 
-         }                                     +|                |                                        | 
-     ],                                        +|                |                                        | 
-     "old_record": {                           +|                |                                        | 
-         "id": 1                               +|                |                                        | 
-     },                                        +|                |                                        | 
-     "commit_timestamp": "2000-01-01T00:01:01Z"+|                |                                        | 
- }                                              |                |                                        | 
+                        rec                         | is_rls_enabled |            subscription_ids            |              errors              
+----------------------------------------------------+----------------+----------------------------------------+----------------------------------
+ {                                                 +| f              | {f4539ebe-c779-5788-bbc1-2421ffaa8954} | {"Error 413: Payload Too Large"}
+     "type": "UPDATE",                             +|                |                                        | 
+     "table": "notes",                             +|                |                                        | 
+     "record": {                                   +|                |                                        | 
+         "id": 1                                   +|                |                                        | 
+     },                                            +|                |                                        | 
+     "schema": "public",                           +|                |                                        | 
+     "columns": [                                  +|                |                                        | 
+         {                                         +|                |                                        | 
+             "name": "id",                         +|                |                                        | 
+             "type": "int4"                        +|                |                                        | 
+         },                                        +|                |                                        | 
+         {                                         +|                |                                        | 
+             "name": "body",                       +|                |                                        | 
+             "type": "text"                        +|                |                                        | 
+         }                                         +|                |                                        | 
+     ],                                            +|                |                                        | 
+     "old_record": {                               +|                |                                        | 
+         "id": 1                                   +|                |                                        | 
+     },                                            +|                |                                        | 
+     "commit_timestamp": "2000-01-01T00:01:01.000Z"+|                |                                        | 
+ }                                                  |                |                                        | 
 (1 row)
 
 drop table public.notes;

--- a/test/expected/test_integration_filters.out
+++ b/test/expected/test_integration_filters.out
@@ -48,47 +48,47 @@ select
     errors
 from
    walrus;
-                      rec                       | is_rls_enabled |                                                 subscription_ids                                                 | errors 
-------------------------------------------------+----------------+------------------------------------------------------------------------------------------------------------------+--------
- {                                             +| f              | {f4539ebe-c779-5788-bbc1-2421ffaa8954}                                                                           | {}
-     "type": "INSERT",                         +|                |                                                                                                                  | 
-     "table": "notes",                         +|                |                                                                                                                  | 
-     "record": {                               +|                |                                                                                                                  | 
-         "id": 1,                              +|                |                                                                                                                  | 
-         "body": "bbb"                         +|                |                                                                                                                  | 
-     },                                        +|                |                                                                                                                  | 
-     "schema": "public",                       +|                |                                                                                                                  | 
-     "columns": [                              +|                |                                                                                                                  | 
-         {                                     +|                |                                                                                                                  | 
-             "name": "id",                     +|                |                                                                                                                  | 
-             "type": "int4"                    +|                |                                                                                                                  | 
-         },                                    +|                |                                                                                                                  | 
-         {                                     +|                |                                                                                                                  | 
-             "name": "body",                   +|                |                                                                                                                  | 
-             "type": "text"                    +|                |                                                                                                                  | 
-         }                                     +|                |                                                                                                                  | 
-     ],                                        +|                |                                                                                                                  | 
-     "commit_timestamp": "2000-01-01T00:01:01Z"+|                |                                                                                                                  | 
- }                                              |                |                                                                                                                  | 
- {                                             +| f              | {f4539ebe-c779-5788-bbc1-2421ffaa8954,5211e8ec-8c25-5c7f-9b03-6ff1eac0159e,11955172-4e1d-5836-925f-2bcb7a287b87} | {}
-     "type": "DELETE",                         +|                |                                                                                                                  | 
-     "table": "notes",                         +|                |                                                                                                                  | 
-     "schema": "public",                       +|                |                                                                                                                  | 
-     "columns": [                              +|                |                                                                                                                  | 
-         {                                     +|                |                                                                                                                  | 
-             "name": "id",                     +|                |                                                                                                                  | 
-             "type": "int4"                    +|                |                                                                                                                  | 
-         },                                    +|                |                                                                                                                  | 
-         {                                     +|                |                                                                                                                  | 
-             "name": "body",                   +|                |                                                                                                                  | 
-             "type": "text"                    +|                |                                                                                                                  | 
-         }                                     +|                |                                                                                                                  | 
-     ],                                        +|                |                                                                                                                  | 
-     "old_record": {                           +|                |                                                                                                                  | 
-         "id": 1                               +|                |                                                                                                                  | 
-     },                                        +|                |                                                                                                                  | 
-     "commit_timestamp": "2000-01-01T00:01:01Z"+|                |                                                                                                                  | 
- }                                              |                |                                                                                                                  | 
+                        rec                         | is_rls_enabled |                                                 subscription_ids                                                 | errors 
+----------------------------------------------------+----------------+------------------------------------------------------------------------------------------------------------------+--------
+ {                                                 +| f              | {f4539ebe-c779-5788-bbc1-2421ffaa8954}                                                                           | {}
+     "type": "INSERT",                             +|                |                                                                                                                  | 
+     "table": "notes",                             +|                |                                                                                                                  | 
+     "record": {                                   +|                |                                                                                                                  | 
+         "id": 1,                                  +|                |                                                                                                                  | 
+         "body": "bbb"                             +|                |                                                                                                                  | 
+     },                                            +|                |                                                                                                                  | 
+     "schema": "public",                           +|                |                                                                                                                  | 
+     "columns": [                                  +|                |                                                                                                                  | 
+         {                                         +|                |                                                                                                                  | 
+             "name": "id",                         +|                |                                                                                                                  | 
+             "type": "int4"                        +|                |                                                                                                                  | 
+         },                                        +|                |                                                                                                                  | 
+         {                                         +|                |                                                                                                                  | 
+             "name": "body",                       +|                |                                                                                                                  | 
+             "type": "text"                        +|                |                                                                                                                  | 
+         }                                         +|                |                                                                                                                  | 
+     ],                                            +|                |                                                                                                                  | 
+     "commit_timestamp": "2000-01-01T00:01:01.000Z"+|                |                                                                                                                  | 
+ }                                                  |                |                                                                                                                  | 
+ {                                                 +| f              | {f4539ebe-c779-5788-bbc1-2421ffaa8954,5211e8ec-8c25-5c7f-9b03-6ff1eac0159e,11955172-4e1d-5836-925f-2bcb7a287b87} | {}
+     "type": "DELETE",                             +|                |                                                                                                                  | 
+     "table": "notes",                             +|                |                                                                                                                  | 
+     "schema": "public",                           +|                |                                                                                                                  | 
+     "columns": [                                  +|                |                                                                                                                  | 
+         {                                         +|                |                                                                                                                  | 
+             "name": "id",                         +|                |                                                                                                                  | 
+             "type": "int4"                        +|                |                                                                                                                  | 
+         },                                        +|                |                                                                                                                  | 
+         {                                         +|                |                                                                                                                  | 
+             "name": "body",                       +|                |                                                                                                                  | 
+             "type": "text"                        +|                |                                                                                                                  | 
+         }                                         +|                |                                                                                                                  | 
+     ],                                            +|                |                                                                                                                  | 
+     "old_record": {                               +|                |                                                                                                                  | 
+         "id": 1                                   +|                |                                                                                                                  | 
+     },                                            +|                |                                                                                                                  | 
+     "commit_timestamp": "2000-01-01T00:01:01.000Z"+|                |                                                                                                                  | 
+ }                                                  |                |                                                                                                                  | 
 (2 rows)
 
 drop table public.notes;

--- a/test/expected/test_integration_in_filter.out
+++ b/test/expected/test_integration_in_filter.out
@@ -48,47 +48,47 @@ select
     errors
 from
    walrus;
-                      rec                       | is_rls_enabled |                                                 subscription_ids                                                 | errors 
-------------------------------------------------+----------------+------------------------------------------------------------------------------------------------------------------+--------
- {                                             +| f              | {f4539ebe-c779-5788-bbc1-2421ffaa8954}                                                                           | {}
-     "type": "INSERT",                         +|                |                                                                                                                  | 
-     "table": "notes",                         +|                |                                                                                                                  | 
-     "record": {                               +|                |                                                                                                                  | 
-         "id": 1,                              +|                |                                                                                                                  | 
-         "body": "bbb"                         +|                |                                                                                                                  | 
-     },                                        +|                |                                                                                                                  | 
-     "schema": "public",                       +|                |                                                                                                                  | 
-     "columns": [                              +|                |                                                                                                                  | 
-         {                                     +|                |                                                                                                                  | 
-             "name": "id",                     +|                |                                                                                                                  | 
-             "type": "int4"                    +|                |                                                                                                                  | 
-         },                                    +|                |                                                                                                                  | 
-         {                                     +|                |                                                                                                                  | 
-             "name": "body",                   +|                |                                                                                                                  | 
-             "type": "text"                    +|                |                                                                                                                  | 
-         }                                     +|                |                                                                                                                  | 
-     ],                                        +|                |                                                                                                                  | 
-     "commit_timestamp": "2000-01-01T00:01:01Z"+|                |                                                                                                                  | 
- }                                              |                |                                                                                                                  | 
- {                                             +| f              | {f4539ebe-c779-5788-bbc1-2421ffaa8954,5211e8ec-8c25-5c7f-9b03-6ff1eac0159e,11955172-4e1d-5836-925f-2bcb7a287b87} | {}
-     "type": "DELETE",                         +|                |                                                                                                                  | 
-     "table": "notes",                         +|                |                                                                                                                  | 
-     "schema": "public",                       +|                |                                                                                                                  | 
-     "columns": [                              +|                |                                                                                                                  | 
-         {                                     +|                |                                                                                                                  | 
-             "name": "id",                     +|                |                                                                                                                  | 
-             "type": "int4"                    +|                |                                                                                                                  | 
-         },                                    +|                |                                                                                                                  | 
-         {                                     +|                |                                                                                                                  | 
-             "name": "body",                   +|                |                                                                                                                  | 
-             "type": "text"                    +|                |                                                                                                                  | 
-         }                                     +|                |                                                                                                                  | 
-     ],                                        +|                |                                                                                                                  | 
-     "old_record": {                           +|                |                                                                                                                  | 
-         "id": 1                               +|                |                                                                                                                  | 
-     },                                        +|                |                                                                                                                  | 
-     "commit_timestamp": "2000-01-01T00:01:01Z"+|                |                                                                                                                  | 
- }                                              |                |                                                                                                                  | 
+                        rec                         | is_rls_enabled |                                                 subscription_ids                                                 | errors 
+----------------------------------------------------+----------------+------------------------------------------------------------------------------------------------------------------+--------
+ {                                                 +| f              | {f4539ebe-c779-5788-bbc1-2421ffaa8954}                                                                           | {}
+     "type": "INSERT",                             +|                |                                                                                                                  | 
+     "table": "notes",                             +|                |                                                                                                                  | 
+     "record": {                                   +|                |                                                                                                                  | 
+         "id": 1,                                  +|                |                                                                                                                  | 
+         "body": "bbb"                             +|                |                                                                                                                  | 
+     },                                            +|                |                                                                                                                  | 
+     "schema": "public",                           +|                |                                                                                                                  | 
+     "columns": [                                  +|                |                                                                                                                  | 
+         {                                         +|                |                                                                                                                  | 
+             "name": "id",                         +|                |                                                                                                                  | 
+             "type": "int4"                        +|                |                                                                                                                  | 
+         },                                        +|                |                                                                                                                  | 
+         {                                         +|                |                                                                                                                  | 
+             "name": "body",                       +|                |                                                                                                                  | 
+             "type": "text"                        +|                |                                                                                                                  | 
+         }                                         +|                |                                                                                                                  | 
+     ],                                            +|                |                                                                                                                  | 
+     "commit_timestamp": "2000-01-01T00:01:01.000Z"+|                |                                                                                                                  | 
+ }                                                  |                |                                                                                                                  | 
+ {                                                 +| f              | {f4539ebe-c779-5788-bbc1-2421ffaa8954,5211e8ec-8c25-5c7f-9b03-6ff1eac0159e,11955172-4e1d-5836-925f-2bcb7a287b87} | {}
+     "type": "DELETE",                             +|                |                                                                                                                  | 
+     "table": "notes",                             +|                |                                                                                                                  | 
+     "schema": "public",                           +|                |                                                                                                                  | 
+     "columns": [                                  +|                |                                                                                                                  | 
+         {                                         +|                |                                                                                                                  | 
+             "name": "id",                         +|                |                                                                                                                  | 
+             "type": "int4"                        +|                |                                                                                                                  | 
+         },                                        +|                |                                                                                                                  | 
+         {                                         +|                |                                                                                                                  | 
+             "name": "body",                       +|                |                                                                                                                  | 
+             "type": "text"                        +|                |                                                                                                                  | 
+         }                                         +|                |                                                                                                                  | 
+     ],                                            +|                |                                                                                                                  | 
+     "old_record": {                               +|                |                                                                                                                  | 
+         "id": 1                                   +|                |                                                                                                                  | 
+     },                                            +|                |                                                                                                                  | 
+     "commit_timestamp": "2000-01-01T00:01:01.000Z"+|                |                                                                                                                  | 
+ }                                                  |                |                                                                                                                  | 
 (2 rows)
 
 -- Confirm that filtering on `in` more than 100 entries throws an error

--- a/test/expected/test_non_public_schema.out
+++ b/test/expected/test_non_public_schema.out
@@ -33,23 +33,23 @@ select
     errors
 from
    walrus;
-                      rec                       | is_rls_enabled |            subscription_ids            | errors 
-------------------------------------------------+----------------+----------------------------------------+--------
- {                                             +| f              | {f4539ebe-c779-5788-bbc1-2421ffaa8954} | {}
-     "type": "INSERT",                         +|                |                                        | 
-     "table": "notes",                         +|                |                                        | 
-     "record": {                               +|                |                                        | 
-         "id": 1                               +|                |                                        | 
-     },                                        +|                |                                        | 
-     "schema": "dev",                          +|                |                                        | 
-     "columns": [                              +|                |                                        | 
-         {                                     +|                |                                        | 
-             "name": "id",                     +|                |                                        | 
-             "type": "int4"                    +|                |                                        | 
-         }                                     +|                |                                        | 
-     ],                                        +|                |                                        | 
-     "commit_timestamp": "2000-01-01T00:01:01Z"+|                |                                        | 
- }                                              |                |                                        | 
+                        rec                         | is_rls_enabled |            subscription_ids            | errors 
+----------------------------------------------------+----------------+----------------------------------------+--------
+ {                                                 +| f              | {f4539ebe-c779-5788-bbc1-2421ffaa8954} | {}
+     "type": "INSERT",                             +|                |                                        | 
+     "table": "notes",                             +|                |                                        | 
+     "record": {                                   +|                |                                        | 
+         "id": 1                                   +|                |                                        | 
+     },                                            +|                |                                        | 
+     "schema": "dev",                              +|                |                                        | 
+     "columns": [                                  +|                |                                        | 
+         {                                         +|                |                                        | 
+             "name": "id",                         +|                |                                        | 
+             "type": "int4"                        +|                |                                        | 
+         }                                         +|                |                                        | 
+     ],                                            +|                |                                        | 
+     "commit_timestamp": "2000-01-01T00:01:01.000Z"+|                |                                        | 
+ }                                                  |                |                                        | 
 (1 row)
 
 drop table dev.notes;

--- a/test/expected/test_old_record_is_primary_key.out
+++ b/test/expected/test_old_record_is_primary_key.out
@@ -38,37 +38,37 @@ select
     errors
 from
    walrus;
-                      rec                       | is_rls_enabled |            subscription_ids            | errors 
-------------------------------------------------+----------------+----------------------------------------+--------
- {                                             +| f              | {f4539ebe-c779-5788-bbc1-2421ffaa8954} | {}
-     "type": "UPDATE",                         +|                |                                        | 
-     "table": "notes",                         +|                |                                        | 
-     "record": {                               +|                |                                        | 
-         "pk1": 1,                             +|                |                                        | 
-         "pk2": "a",                           +|                |                                        | 
-         "body": "take out trash"              +|                |                                        | 
-     },                                        +|                |                                        | 
-     "schema": "public",                       +|                |                                        | 
-     "columns": [                              +|                |                                        | 
-         {                                     +|                |                                        | 
-             "name": "pk1",                    +|                |                                        | 
-             "type": "int4"                    +|                |                                        | 
-         },                                    +|                |                                        | 
-         {                                     +|                |                                        | 
-             "name": "pk2",                    +|                |                                        | 
-             "type": "bpchar"                  +|                |                                        | 
-         },                                    +|                |                                        | 
-         {                                     +|                |                                        | 
-             "name": "body",                   +|                |                                        | 
-             "type": "text"                    +|                |                                        | 
-         }                                     +|                |                                        | 
-     ],                                        +|                |                                        | 
-     "old_record": {                           +|                |                                        | 
-         "pk1": 1,                             +|                |                                        | 
-         "pk2": "a"                            +|                |                                        | 
-     },                                        +|                |                                        | 
-     "commit_timestamp": "2000-01-01T00:01:01Z"+|                |                                        | 
- }                                              |                |                                        | 
+                        rec                         | is_rls_enabled |            subscription_ids            | errors 
+----------------------------------------------------+----------------+----------------------------------------+--------
+ {                                                 +| f              | {f4539ebe-c779-5788-bbc1-2421ffaa8954} | {}
+     "type": "UPDATE",                             +|                |                                        | 
+     "table": "notes",                             +|                |                                        | 
+     "record": {                                   +|                |                                        | 
+         "pk1": 1,                                 +|                |                                        | 
+         "pk2": "a",                               +|                |                                        | 
+         "body": "take out trash"                  +|                |                                        | 
+     },                                            +|                |                                        | 
+     "schema": "public",                           +|                |                                        | 
+     "columns": [                                  +|                |                                        | 
+         {                                         +|                |                                        | 
+             "name": "pk1",                        +|                |                                        | 
+             "type": "int4"                        +|                |                                        | 
+         },                                        +|                |                                        | 
+         {                                         +|                |                                        | 
+             "name": "pk2",                        +|                |                                        | 
+             "type": "bpchar"                      +|                |                                        | 
+         },                                        +|                |                                        | 
+         {                                         +|                |                                        | 
+             "name": "body",                       +|                |                                        | 
+             "type": "text"                        +|                |                                        | 
+         }                                         +|                |                                        | 
+     ],                                            +|                |                                        | 
+     "old_record": {                               +|                |                                        | 
+         "pk1": 1,                                 +|                |                                        | 
+         "pk2": "a"                                +|                |                                        | 
+     },                                            +|                |                                        | 
+     "commit_timestamp": "2000-01-01T00:01:01.000Z"+|                |                                        | 
+ }                                                  |                |                                        | 
 (1 row)
 
 drop table public.notes;

--- a/test/expected/test_old_record_replica_identity_full.out
+++ b/test/expected/test_old_record_replica_identity_full.out
@@ -40,38 +40,38 @@ select
     errors
 from
    walrus;
-                      rec                       | is_rls_enabled |            subscription_ids            | errors 
-------------------------------------------------+----------------+----------------------------------------+--------
- {                                             +| f              | {f4539ebe-c779-5788-bbc1-2421ffaa8954} | {}
-     "type": "UPDATE",                         +|                |                                        | 
-     "table": "notes",                         +|                |                                        | 
-     "record": {                               +|                |                                        | 
-         "pk1": 1,                             +|                |                                        | 
-         "pk2": "a",                           +|                |                                        | 
-         "body": "take out trash"              +|                |                                        | 
-     },                                        +|                |                                        | 
-     "schema": "public",                       +|                |                                        | 
-     "columns": [                              +|                |                                        | 
-         {                                     +|                |                                        | 
-             "name": "pk1",                    +|                |                                        | 
-             "type": "int4"                    +|                |                                        | 
-         },                                    +|                |                                        | 
-         {                                     +|                |                                        | 
-             "name": "pk2",                    +|                |                                        | 
-             "type": "bpchar"                  +|                |                                        | 
-         },                                    +|                |                                        | 
-         {                                     +|                |                                        | 
-             "name": "body",                   +|                |                                        | 
-             "type": "text"                    +|                |                                        | 
-         }                                     +|                |                                        | 
-     ],                                        +|                |                                        | 
-     "old_record": {                           +|                |                                        | 
-         "pk1": 1,                             +|                |                                        | 
-         "pk2": "a",                           +|                |                                        | 
-         "body": "take out trash"              +|                |                                        | 
-     },                                        +|                |                                        | 
-     "commit_timestamp": "2000-01-01T00:01:01Z"+|                |                                        | 
- }                                              |                |                                        | 
+                        rec                         | is_rls_enabled |            subscription_ids            | errors 
+----------------------------------------------------+----------------+----------------------------------------+--------
+ {                                                 +| f              | {f4539ebe-c779-5788-bbc1-2421ffaa8954} | {}
+     "type": "UPDATE",                             +|                |                                        | 
+     "table": "notes",                             +|                |                                        | 
+     "record": {                                   +|                |                                        | 
+         "pk1": 1,                                 +|                |                                        | 
+         "pk2": "a",                               +|                |                                        | 
+         "body": "take out trash"                  +|                |                                        | 
+     },                                            +|                |                                        | 
+     "schema": "public",                           +|                |                                        | 
+     "columns": [                                  +|                |                                        | 
+         {                                         +|                |                                        | 
+             "name": "pk1",                        +|                |                                        | 
+             "type": "int4"                        +|                |                                        | 
+         },                                        +|                |                                        | 
+         {                                         +|                |                                        | 
+             "name": "pk2",                        +|                |                                        | 
+             "type": "bpchar"                      +|                |                                        | 
+         },                                        +|                |                                        | 
+         {                                         +|                |                                        | 
+             "name": "body",                       +|                |                                        | 
+             "type": "text"                        +|                |                                        | 
+         }                                         +|                |                                        | 
+     ],                                            +|                |                                        | 
+     "old_record": {                               +|                |                                        | 
+         "pk1": 1,                                 +|                |                                        | 
+         "pk2": "a",                               +|                |                                        | 
+         "body": "take out trash"                  +|                |                                        | 
+     },                                            +|                |                                        | 
+     "commit_timestamp": "2000-01-01T00:01:01.000Z"+|                |                                        | 
+ }                                                  |                |                                        | 
 (1 row)
 
 drop table public.notes;

--- a/test/expected/test_rls_skips_subscriber.out
+++ b/test/expected/test_rls_skips_subscriber.out
@@ -88,7 +88,7 @@ begin;
              "type": "uuid"                               +|                |                                        | 
          }                                                +|                |                                        | 
      ],                                                   +|                |                                        | 
-     "commit_timestamp": "2000-01-01T00:01:01Z"           +|                |                                        | 
+     "commit_timestamp": "2000-01-01T00:01:01.000Z"       +|                |                                        | 
  }                                                         |                |                                        | 
 (1 row)
 

--- a/test/expected/test_simple_delete.out
+++ b/test/expected/test_simple_delete.out
@@ -32,27 +32,27 @@ select
     errors
 from
    walrus;
-                      rec                       | is_rls_enabled |            subscription_ids            | errors 
-------------------------------------------------+----------------+----------------------------------------+--------
- {                                             +| f              | {f4539ebe-c779-5788-bbc1-2421ffaa8954} | {}
-     "type": "DELETE",                         +|                |                                        | 
-     "table": "notes",                         +|                |                                        | 
-     "schema": "public",                       +|                |                                        | 
-     "columns": [                              +|                |                                        | 
-         {                                     +|                |                                        | 
-             "name": "id",                     +|                |                                        | 
-             "type": "int4"                    +|                |                                        | 
-         },                                    +|                |                                        | 
-         {                                     +|                |                                        | 
-             "name": "body",                   +|                |                                        | 
-             "type": "text"                    +|                |                                        | 
-         }                                     +|                |                                        | 
-     ],                                        +|                |                                        | 
-     "old_record": {                           +|                |                                        | 
-         "id": 1                               +|                |                                        | 
-     },                                        +|                |                                        | 
-     "commit_timestamp": "2000-01-01T00:01:01Z"+|                |                                        | 
- }                                              |                |                                        | 
+                        rec                         | is_rls_enabled |            subscription_ids            | errors 
+----------------------------------------------------+----------------+----------------------------------------+--------
+ {                                                 +| f              | {f4539ebe-c779-5788-bbc1-2421ffaa8954} | {}
+     "type": "DELETE",                             +|                |                                        | 
+     "table": "notes",                             +|                |                                        | 
+     "schema": "public",                           +|                |                                        | 
+     "columns": [                                  +|                |                                        | 
+         {                                         +|                |                                        | 
+             "name": "id",                         +|                |                                        | 
+             "type": "int4"                        +|                |                                        | 
+         },                                        +|                |                                        | 
+         {                                         +|                |                                        | 
+             "name": "body",                       +|                |                                        | 
+             "type": "text"                        +|                |                                        | 
+         }                                         +|                |                                        | 
+     ],                                            +|                |                                        | 
+     "old_record": {                               +|                |                                        | 
+         "id": 1                                   +|                |                                        | 
+     },                                            +|                |                                        | 
+     "commit_timestamp": "2000-01-01T00:01:01.000Z"+|                |                                        | 
+ }                                                  |                |                                        | 
 (1 row)
 
 drop table public.notes;

--- a/test/expected/test_simple_insert.out
+++ b/test/expected/test_simple_insert.out
@@ -30,23 +30,23 @@ select
     errors
 from
    walrus;
-                      rec                       | is_rls_enabled |            subscription_ids            | errors 
-------------------------------------------------+----------------+----------------------------------------+--------
- {                                             +| f              | {f4539ebe-c779-5788-bbc1-2421ffaa8954} | {}
-     "type": "INSERT",                         +|                |                                        | 
-     "table": "notes",                         +|                |                                        | 
-     "record": {                               +|                |                                        | 
-         "id": 1                               +|                |                                        | 
-     },                                        +|                |                                        | 
-     "schema": "public",                       +|                |                                        | 
-     "columns": [                              +|                |                                        | 
-         {                                     +|                |                                        | 
-             "name": "id",                     +|                |                                        | 
-             "type": "int4"                    +|                |                                        | 
-         }                                     +|                |                                        | 
-     ],                                        +|                |                                        | 
-     "commit_timestamp": "2000-01-01T00:01:01Z"+|                |                                        | 
- }                                              |                |                                        | 
+                        rec                         | is_rls_enabled |            subscription_ids            | errors 
+----------------------------------------------------+----------------+----------------------------------------+--------
+ {                                                 +| f              | {f4539ebe-c779-5788-bbc1-2421ffaa8954} | {}
+     "type": "INSERT",                             +|                |                                        | 
+     "table": "notes",                             +|                |                                        | 
+     "record": {                                   +|                |                                        | 
+         "id": 1                                   +|                |                                        | 
+     },                                            +|                |                                        | 
+     "schema": "public",                           +|                |                                        | 
+     "columns": [                                  +|                |                                        | 
+         {                                         +|                |                                        | 
+             "name": "id",                         +|                |                                        | 
+             "type": "int4"                        +|                |                                        | 
+         }                                         +|                |                                        | 
+     ],                                            +|                |                                        | 
+     "commit_timestamp": "2000-01-01T00:01:01.000Z"+|                |                                        | 
+ }                                                  |                |                                        | 
 (1 row)
 
 drop table public.notes;

--- a/test/expected/test_simple_update.out
+++ b/test/expected/test_simple_update.out
@@ -32,31 +32,31 @@ select
     errors
 from
    walrus;
-                      rec                       | is_rls_enabled |            subscription_ids            | errors 
-------------------------------------------------+----------------+----------------------------------------+--------
- {                                             +| f              | {f4539ebe-c779-5788-bbc1-2421ffaa8954} | {}
-     "type": "UPDATE",                         +|                |                                        | 
-     "table": "notes",                         +|                |                                        | 
-     "record": {                               +|                |                                        | 
-         "id": 2,                              +|                |                                        | 
-         "body": "take out trash"              +|                |                                        | 
-     },                                        +|                |                                        | 
-     "schema": "public",                       +|                |                                        | 
-     "columns": [                              +|                |                                        | 
-         {                                     +|                |                                        | 
-             "name": "id",                     +|                |                                        | 
-             "type": "int4"                    +|                |                                        | 
-         },                                    +|                |                                        | 
-         {                                     +|                |                                        | 
-             "name": "body",                   +|                |                                        | 
-             "type": "text"                    +|                |                                        | 
-         }                                     +|                |                                        | 
-     ],                                        +|                |                                        | 
-     "old_record": {                           +|                |                                        | 
-         "id": 1                               +|                |                                        | 
-     },                                        +|                |                                        | 
-     "commit_timestamp": "2000-01-01T00:01:01Z"+|                |                                        | 
- }                                              |                |                                        | 
+                        rec                         | is_rls_enabled |            subscription_ids            | errors 
+----------------------------------------------------+----------------+----------------------------------------+--------
+ {                                                 +| f              | {f4539ebe-c779-5788-bbc1-2421ffaa8954} | {}
+     "type": "UPDATE",                             +|                |                                        | 
+     "table": "notes",                             +|                |                                        | 
+     "record": {                                   +|                |                                        | 
+         "id": 2,                                  +|                |                                        | 
+         "body": "take out trash"                  +|                |                                        | 
+     },                                            +|                |                                        | 
+     "schema": "public",                           +|                |                                        | 
+     "columns": [                                  +|                |                                        | 
+         {                                         +|                |                                        | 
+             "name": "id",                         +|                |                                        | 
+             "type": "int4"                        +|                |                                        | 
+         },                                        +|                |                                        | 
+         {                                         +|                |                                        | 
+             "name": "body",                       +|                |                                        | 
+             "type": "text"                        +|                |                                        | 
+         }                                         +|                |                                        | 
+     ],                                            +|                |                                        | 
+     "old_record": {                               +|                |                                        | 
+         "id": 1                                   +|                |                                        | 
+     },                                            +|                |                                        | 
+     "commit_timestamp": "2000-01-01T00:01:01.000Z"+|                |                                        | 
+ }                                                  |                |                                        | 
 (1 row)
 
 drop table public.notes;

--- a/test/expected/test_subscribers_multiple_roles.out
+++ b/test/expected/test_subscribers_multiple_roles.out
@@ -38,43 +38,43 @@ select
     errors
 from
    walrus;
-                      rec                       | is_rls_enabled |            subscription_ids            | errors 
-------------------------------------------------+----------------+----------------------------------------+--------
- {                                             +| f              | {5211e8ec-8c25-5c7f-9b03-6ff1eac0159e} | {}
-     "type": "INSERT",                         +|                |                                        | 
-     "table": "notes",                         +|                |                                        | 
-     "record": {                               +|                |                                        | 
-         "id": 1,                              +|                |                                        | 
-         "body": "hello"                       +|                |                                        | 
-     },                                        +|                |                                        | 
-     "schema": "public",                       +|                |                                        | 
-     "columns": [                              +|                |                                        | 
-         {                                     +|                |                                        | 
-             "name": "id",                     +|                |                                        | 
-             "type": "int4"                    +|                |                                        | 
-         },                                    +|                |                                        | 
-         {                                     +|                |                                        | 
-             "name": "body",                   +|                |                                        | 
-             "type": "text"                    +|                |                                        | 
-         }                                     +|                |                                        | 
-     ],                                        +|                |                                        | 
-     "commit_timestamp": "2000-01-01T00:01:01Z"+|                |                                        | 
- }                                              |                |                                        | 
- {                                             +| f              | {f4539ebe-c779-5788-bbc1-2421ffaa8954} | {}
-     "type": "INSERT",                         +|                |                                        | 
-     "table": "notes",                         +|                |                                        | 
-     "record": {                               +|                |                                        | 
-         "id": 1                               +|                |                                        | 
-     },                                        +|                |                                        | 
-     "schema": "public",                       +|                |                                        | 
-     "columns": [                              +|                |                                        | 
-         {                                     +|                |                                        | 
-             "name": "id",                     +|                |                                        | 
-             "type": "int4"                    +|                |                                        | 
-         }                                     +|                |                                        | 
-     ],                                        +|                |                                        | 
-     "commit_timestamp": "2000-01-01T00:01:01Z"+|                |                                        | 
- }                                              |                |                                        | 
+                        rec                         | is_rls_enabled |            subscription_ids            | errors 
+----------------------------------------------------+----------------+----------------------------------------+--------
+ {                                                 +| f              | {5211e8ec-8c25-5c7f-9b03-6ff1eac0159e} | {}
+     "type": "INSERT",                             +|                |                                        | 
+     "table": "notes",                             +|                |                                        | 
+     "record": {                                   +|                |                                        | 
+         "id": 1,                                  +|                |                                        | 
+         "body": "hello"                           +|                |                                        | 
+     },                                            +|                |                                        | 
+     "schema": "public",                           +|                |                                        | 
+     "columns": [                                  +|                |                                        | 
+         {                                         +|                |                                        | 
+             "name": "id",                         +|                |                                        | 
+             "type": "int4"                        +|                |                                        | 
+         },                                        +|                |                                        | 
+         {                                         +|                |                                        | 
+             "name": "body",                       +|                |                                        | 
+             "type": "text"                        +|                |                                        | 
+         }                                         +|                |                                        | 
+     ],                                            +|                |                                        | 
+     "commit_timestamp": "2000-01-01T00:01:01.000Z"+|                |                                        | 
+ }                                                  |                |                                        | 
+ {                                                 +| f              | {f4539ebe-c779-5788-bbc1-2421ffaa8954} | {}
+     "type": "INSERT",                             +|                |                                        | 
+     "table": "notes",                             +|                |                                        | 
+     "record": {                                   +|                |                                        | 
+         "id": 1                                   +|                |                                        | 
+     },                                            +|                |                                        | 
+     "schema": "public",                           +|                |                                        | 
+     "columns": [                                  +|                |                                        | 
+         {                                         +|                |                                        | 
+             "name": "id",                         +|                |                                        | 
+             "type": "int4"                        +|                |                                        | 
+         }                                         +|                |                                        | 
+     ],                                            +|                |                                        | 
+     "commit_timestamp": "2000-01-01T00:01:01.000Z"+|                |                                        | 
+ }                                                  |                |                                        | 
 (2 rows)
 
 drop table public.notes;


### PR DESCRIPTION
## What kind of change does this PR introduce?
Adds milliseconds to commit_timestamp

Ref:
https://github.com/supabase/realtime/pull/453