### PR TITLE
docs: update max_record_bytes default to 1MiB in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ where
 
 ### max_record_bytes
 
-`max_record_bytes` (default 1MB): Controls the maximum size of a WAL record that will be emitted with complete `record` and `old_record` data. When the size of the wal2json record exceeds `max_record_bytes` the `record` and `old_record` objects are filtered to include only fields with a value size <= 64 bytes. The `errors` output array is set to contain the string `"Error 413: Payload Too Large"`.
+`max_record_bytes` (default 1 MiB): Controls the maximum size of a WAL record that will be emitted with complete `record` and `old_record` data. When the size of the wal2json record exceeds `max_record_bytes` the `record` and `old_record` objects are filtered to include only fields with a value size <= 64 bytes. The `errors` output array is set to contain the string `"Error 413: Payload Too Large"`.
 
 Ex:
 ```sql


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the new behavior?

Technically, default for `max_record_bytes` is 1 MiB so changing it in README to reflect that.
